### PR TITLE
Turn default.nix into a simple interface

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,12 @@
-(import ./nix/flake-compat.nix).defaultNix
+/*
+  To import, use
+
+    let
+      inherit (import effectsSrc { inherit pkgs; }) effects;
+    in
+      ...
+ */
+
+{ pkgs }: rec {
+  effects = import ./effects/default.nix effects pkgs;
+}

--- a/docs/modules/ROOT/pages/guide/import-or-pin.adoc
+++ b/docs/modules/ROOT/pages/guide/import-or-pin.adoc
@@ -63,7 +63,16 @@ Add as a source
 niv add hercules-ci/hercules-ci-effects
 ```
 
-Either add the overlay
+Add
+
+```nix
+let
+  inherit (import sources.hercules-ci-effects { inherit pkgs; }) effects;
+in
+  /* ... */
+```
+
+or if you prefer to use the overlay:
 
 ```nix
 let
@@ -75,15 +84,7 @@ let
     ];
     system = /* ... */;
   }
-in /* ... */
-```
-
-or if you prefer not to use the overlay, use:
-
-```nix
-let
-  effects = import (sources.hercules-ci-effects + "/effects") effects pkgs;
-in /* ... */
+in /* use pkgs.effects */
 ```
 
 == Other methods

--- a/effects/default.nix
+++ b/effects/default.nix
@@ -1,4 +1,4 @@
-# The resulting attribute set. E.g. let effects = import ./default.nix effects pkgs
+# The resulting attribute set. See ../default.nix.
 self:
 
 # Nixpkgs

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,1 +1,1 @@
-(import ../default.nix).tests
+(import ./flake-compat.nix).defaultNix.tests


### PR DESCRIPTION
If you were using the old `flake-compat` result, you *could* call `nix/flake-compat.nix` directly, but I would recommend to follow the documented import methods instead.