### PR TITLE
Issue 38 nix darwin switch not just activate

### DIFF
--- a/effects/nix-darwin/run-nix-darwin.nix
+++ b/effects/nix-darwin/run-nix-darwin.nix
@@ -50,6 +50,9 @@ mkEffect (removeAttrs args ["configuration" "ssh"] // {
   };
   effectScript = ''
     ${effects.ssh ssh ''
+      echo >&2 "remote nix version:"
+      nix-env --version >&2
+      nix-env -p ${conf.config.system.profile} --set ${conf.system}
       ${conf.system}/sw/bin/darwin-rebuild activate
     ''}
   '';

--- a/effects/nix-darwin/run-nix-darwin.nix
+++ b/effects/nix-darwin/run-nix-darwin.nix
@@ -50,9 +50,14 @@ mkEffect (removeAttrs args ["configuration" "ssh"] // {
   };
   effectScript = ''
     ${effects.ssh ssh ''
+      set -eu
       echo >&2 "remote nix version:"
       nix-env --version >&2
-      nix-env -p ${conf.config.system.profile} --set ${conf.system}
+      if [ "$USER" != root ] && [ ! -w $(dirname "${conf.config.system.profile}") ]; then
+        sudo nix-env -p ${conf.config.system.profile} --set ${conf.system}
+      else
+        nix-env -p ${conf.config.system.profile} --set ${conf.system}
+      fi
       ${conf.system}/sw/bin/darwin-rebuild activate
     ''}
   '';


### PR DESCRIPTION
`activate` does not set the profile link. This is the responsibility
of the `switch` command, that also evaluates, which we don't want
so we set the profile in the effect itself to complete it.

Fixes #38 