### PR TITLE
Remove phase headers

### DIFF
--- a/effects/effect/effects-setup-hook.sh
+++ b/effects/effect/effects-setup-hook.sh
@@ -93,6 +93,21 @@ unpackCmdHooks+=(simpleCopyUnpack)
 
 
 # ----------------------------------------------------------------------------
+# only show phase headers when debugging
+
+overrideShowPhaseHeader(){
+  if [[ -z "${NIX_DEBUG:-}" ]]; then
+    # override it
+    showPhaseHeader() {
+      :
+    }
+  fi
+}
+
+postHooks+=(overrideShowPhaseHeader)
+
+
+# ----------------------------------------------------------------------------
 # warn if run in wrong environment
 
 


### PR DESCRIPTION
They add a lot of noise and some suggest that things happen that do not occur, e.g. putStatePhase, which is often empty.