### PR TITLE
Disable runNixOps2 action argument because of nixops#1499

### DIFF
--- a/effects/nixops2/run-nixops2.nix
+++ b/effects/nixops2/run-nixops2.nix
@@ -117,9 +117,16 @@ let
 
   name2 = if name != null then name else "nixops";
 
+  throwIfNot = c: msg: if !c then throw msg else x: x;
+
 in
 # Either flake or networkFiles must be set.
 assert ((flake == null) != (networkFiles == null));
+
+throwIfNot
+  ("action" == "switch" || (args?makeAnException && args.makeAnException == "I know this can corrupt the state, until https://github.com/NixOS/nixops/issues/1499 is resolved."))
+  "The runNixOps2 action parameter is disabled until https://github.com/NixOS/nixops/issues/1499 is resolved."
+
 mkEffect (
   {
     NIX_PATH="nixpkgs=${path}";

--- a/effects/nixops2/test/default.nix
+++ b/effects/nixops2/test/default.nix
@@ -81,6 +81,7 @@ let
       echo experimental-features = nix-command flakes >>~/.config/nix/nix.conf
     '';
     action = "dry-run";
+    makeAnException = "I know this can corrupt the state, until https://github.com/NixOS/nixops/issues/1499 is resolved.";
     userSetupScript = ''
       writeAWSSecret nixops-example nixops-example
     '';


### PR DESCRIPTION
Prevent others from encountering https://github.com/NixOS/nixops/issues/1499

State can be reverted, but it's still a really bad bug if you find out too late.