### PR TITLE
runNixOps: Make check scripts easier to override

### DIFF
--- a/effects/nixops/run-nixops.nix
+++ b/effects/nixops/run-nixops.nix
@@ -170,12 +170,12 @@ mkEffect (
   # To quote the NixOps help:
   #   check the state of the machines in the network (note that this might alter
   #   the internal nixops state to consolidate with the real state of the resource)
-  effectCheckScript = lib.optionalString canModifyState ''
+  effectCheckScript = args.effectCheckScript or (lib.optionalString canModifyState ''
     nixops check
-  '';
+  '');
 
-  priorCheckScript = ''
+  priorCheckScript = args.priorCheckScript or (''
     nixops check
-  '';
+  '');
 
 })


### PR DESCRIPTION
Was technically possible with overrideAttrs, but that's annoying.