### PR TITLE
netlifyDeploy: use JSON output and store it in a file named `netlify-result.json` for use in postEffect

### DIFF
--- a/effects/netlify/default.nix
+++ b/effects/netlify/default.nix
@@ -21,6 +21,7 @@ mkEffect (args // {
   secretsMap."netlify" = secretName;
   effectScript = ''
     netlify deploy \
+      --json \
       --auth=$(readSecretString netlify .${secretField}) \
       ${lib.escapeShellArgs deployArgs}
   '';

--- a/effects/netlify/default.nix
+++ b/effects/netlify/default.nix
@@ -14,6 +14,7 @@ let
   deployArgs = [
     "--dir=${content}"
     "--site=${siteId}"
+    "--json"
   ] ++ lib.optionals productionDeployment [ "--prod" ];
 in
 mkEffect (args // {
@@ -21,8 +22,9 @@ mkEffect (args // {
   secretsMap."netlify" = secretName;
   effectScript = ''
     netlify deploy \
-      --json \
       --auth=$(readSecretString netlify .${secretField}) \
-      ${lib.escapeShellArgs deployArgs}
+      ${lib.escapeShellArgs deployArgs} | tee netlify-result.json
+    # netlify does not print a newline after the json output, so we add it to keep the log tidy
+    echo
   '';
 })


### PR DESCRIPTION
The default output of netlify-cli is useless and spams the terminal with animation, which is not useful for reading by human or machine.

![image](https://user-images.githubusercontent.com/26458780/173120969-2bd73edb-0659-48c9-9f49-ef5cbda4100a.png)

a postEffect can now use the JSON output of netlifyDeploy by reading the file named 'out', analogous to a $out in a normal Nix derivation. This is a good placeholder until effects support real outputs.