### PR TITLE
netlifyDeploy: wrap secretsMap

### DIFF
--- a/effects/netlify/default.nix
+++ b/effects/netlify/default.nix
@@ -8,6 +8,7 @@ args@{ content
 , secretField ? "token"
 , siteId
 , productionDeployment ? false
+, secretsMap ? {}
 , ...
 }:
 let
@@ -18,7 +19,7 @@ let
 in
 mkEffect (args // {
   inputs = [ netlify-cli ];
-  secretsMap."netlify" = secretName;
+  secretsMap = secretsMap // { "netlify" = secretName; };
   effectScript = ''
     netlify deploy \
       --auth=$(readSecretString netlify .${secretField}) \


### PR DESCRIPTION
Without this, new secretsMap(s) cannot be introduced to the function call