### PR TITLE
netlifyDeploy: allow additional secretsMap

### DIFF
--- a/effects/netlify/default.nix
+++ b/effects/netlify/default.nix
@@ -19,7 +19,7 @@ let
 in
 mkEffect (args // {
   inputs = [ netlify-cli ];
-  secretsMap = secretsMap // { "netlify" = secretName; };
+  secretsMap = { "netlify" = secretName; } // secretsMap;
   effectScript = ''
     netlify deploy \
       --auth=$(readSecretString netlify .${secretField}) \


### PR DESCRIPTION
Prior to this commit, only one secretsMap could be passed into the mkEffect function call, meaning that postEffect scripts that want to use secrets via readSecretString could not.