### PR TITLE
`netlifyDeploy`: log before deploy

### DIFF
--- a/effects/effect/effect.nix
+++ b/effects/effect/effect.nix
@@ -108,6 +108,7 @@ invokeOverride mkDrv {
     eval "$effectCheckScript"
     runHook postEffectCheck
   '';
+  effectCheckScript = "";
 
   getStatePhase = ''
     runHook preGetState
@@ -115,6 +116,8 @@ invokeOverride mkDrv {
     runHook postGetState
     registerPutStatePhaseOnFailure
   '';
+  getStateScript = "";
+
   putStatePhase = ''
     if [[ -z ''${PUT_STATE_DONE:-} ]]; then
       runHook prePutState
@@ -125,4 +128,5 @@ invokeOverride mkDrv {
       echo 1>&2 "NOTE: State has already been uploaded and was not uploaded again."
     fi
   '';
+  putStateScript = "";
 }

--- a/effects/netlify/default.nix
+++ b/effects/netlify/default.nix
@@ -28,6 +28,7 @@ mkEffect (args // {
   netlifySecretField = secretField;
   NETLIFY_SITE_ID = siteId;
   effectScript = ''
+    echo 1>&2 Running netlify deploy...
     netlify deploy \
       ${lib.escapeShellArgs deployArgs} | tee netlify-result.json
     # netlify does not print a newline after the json output, so we add it to keep the log tidy


### PR DESCRIPTION
When building an impure `contents`, it might not be clear what's happening. `netlify deploy` can be slow.