### PR TITLE
Flake updater and defining `herculesCI.on*` jobs with options

### DIFF
--- a/effects/default.nix
+++ b/effects/default.nix
@@ -23,6 +23,8 @@ in
       }
     );
 
+  flakeUpdate = callPackage ./flake-update { };
+
   netlifyDeploy = callPackage ./netlify { };
   netlifySetupHook = pkgs.runCommand "hercules-ci-netlify-setup-hook" {} ''
     mkdir -p $out/nix-support
@@ -50,7 +52,7 @@ in
 
   ssh = callPackage ./ssh/call-ssh.nix { };
 
-  effectVMTest = callPackage ./effect-vm-test { };
+  effectVMTest = callPackage ./effect-vm-test { extraModule = { config.hci = pkgs.hci; }; };
 
   effects = self;
 

--- a/effects/effect-vm-test/default.nix
+++ b/effects/effect-vm-test/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, pkgs, extraModule, ... }:
 let
   inherit (lib) isFunction mapAttrsToList;
 
@@ -7,7 +7,7 @@ let
 in
 
 module: nixos-lib.runTest {
-  imports = [ ./effects-module.nix module ];
+  imports = [ ./effects-module.nix module extraModule ];
   config = {
     hostPkgs = pkgs;
   };

--- a/effects/effect-vm-test/effects-module.nix
+++ b/effects/effect-vm-test/effects-module.nix
@@ -10,11 +10,6 @@ let
 
   nixos-lib = import (pkgs.path + "/nixos/lib") { inherit lib; };
 
-  # TODO: remove when next hci release is in Nixpkgs
-  hci =
-    let flake = builtins.getFlake "git+https://github.com/hercules-ci/hercules-ci-agent?ref=master&rev=6e298a833dc5321f7f9ff25bc243e4d7c65d928d";
-    in flake.packages.x86_64-linux.hercules-ci-cli;
-
   wrapEffect = name: effect:
     let
       eff = effect.overrideAttrs (o: {
@@ -58,6 +53,12 @@ let
 in
 {
   options = {
+    hci = mkOption {
+      type = types.package;
+      description = ''
+        Hercules CI CLI package to use in the test runner.
+      '';
+    };
     effects = mkOption {
       description = ''
         An attribute set of effects.
@@ -81,7 +82,7 @@ in
 
   config = {
     nodes.agent = {
-      environment.systemPackages = [ hci ] ++ mapAttrsToList wrapEffect test.config.effects;
+      environment.systemPackages = [ config.hci ] ++ mapAttrsToList wrapEffect test.config.effects;
       # Might actually want to use `hci secret add` instead?
       # That will support dynamic secrets, like a host key that's
       # generated on the host.

--- a/effects/flake-update/default.nix
+++ b/effects/flake-update/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, mkEffect
+, pkgs
+}:
+
+let
+  parseURL = gitRemote:
+    let m = builtins.match "([a-z]*)://([^/]*)(/?.*)" gitRemote;
+    in if m == null then throw "Could not determine host in gitRemote url ${gitRemote}" else {
+      scheme = lib.elemAt m 0;
+      host = lib.elemAt m 1;
+      path = lib.elemAt m 2;
+    };
+in
+
+args@{ gitRemote
+, tokenSecret ? { type = "GitToken"; }
+, user ? "git"
+, updateBranch ? "flake-update"
+}:
+let
+  url = parseURL gitRemote;
+in
+mkEffect ({
+  secretsMap.token = tokenSecret;
+  inherit gitRemote user updateBranch;
+  inherit (url) scheme host path;
+
+  name = "flake-update";
+  dontUnpack = true;
+  nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
+    pkgs.git
+    pkgs.nix
+  ];
+
+  EMAIL = "noreply+hercules-ci-effects@hercules-ci.com";
+  GIT_AUTHOR_NAME = "Hercules CI Effects";
+  GIT_COMMITTER_NAME = "Hercules CI Effects";
+  PAGER = "cat";
+
+  userSetupScript = ''
+    # set -x
+    echo "$scheme://$user:$(readSecretString token .token)@$host$path" >~/.git-credentials
+    git config --global credential.helper store
+  '';
+  effectScript = ''
+    git clone "$gitRemote" repo
+    cd repo
+    if git rev-parse "refs/remotes/origin/$updateBranch" &>/dev/null; then
+      git checkout "$updateBranch"
+    else
+      git checkout -b "$updateBranch"
+    fi
+
+    rev_before="$(git rev-parse HEAD)"
+
+    echo 1>&2 'Running nix flake update...'
+
+    nix flake update \
+      --commit-lock-file \
+      --extra-experimental-features 'nix-command flakes'
+
+    rev_after="$(git rev-parse HEAD)"
+
+    if [[ $rev_before == $rev_after ]]; then
+      echo 1>&2 'No updates to push.'
+    else
+      git push origin "$updateBranch"
+    fi
+  '';
+})

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -1,0 +1,46 @@
+{ config, lib, withSystem, ... }:
+let
+  inherit (lib) mkOption types optionalAttrs;
+  cfg = config.flake-update;
+in
+{
+  options = {
+    flake-update = {
+      enable = lib.mkEnableOption "Scheduled flake update job";
+      updateBranch = mkOption {
+        type = types.str;
+        default = "flake-update";
+        example = "update";
+        description = lib.mdDoc ''
+          To which branch to push the updated flake lock.
+        '';
+      };
+      effect.system = mkOption {
+        type = types.str;
+        default = config.defaultEffectSystem;
+        defaultText = lib.literalExpression "config.defaultEffectSystem";
+        example = "aarch64-linux";
+        description = lib.mdDoc ''
+          The [system](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-system) on which to run the flake update job.
+        '';
+      };
+    };
+  };
+  config = {
+    herculesCI = herculesCI@{ config, ... }: optionalAttrs (cfg.enable) {
+      onSchedule.flake-update = {
+        outputs = {
+          effects = {
+            flake-update = withSystem cfg.effect.system ({ config, pkgs, hci-effects, ... }:
+              hci-effects.flakeUpdate {
+                gitRemote = herculesCI.config.repo.remoteHttpUrl;
+                user = "x-access-token";
+                inherit (cfg) updateBranch;
+              }
+            );
+          };
+        };
+      };
+    };
+  };
+}

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -15,6 +15,12 @@ in
           To which branch to push the updated flake lock.
         '';
       };
+      when = mkOption {
+        type = types.raw;
+        description = lib.mdDoc ''
+          See `herculesCI.onSchedule.<name>.when` for details.
+        '';
+      };
       effect.system = mkOption {
         type = types.str;
         default = config.defaultEffectSystem;
@@ -29,6 +35,7 @@ in
   config = {
     herculesCI = herculesCI@{ config, ... }: optionalAttrs (cfg.enable) {
       onSchedule.flake-update = {
+        inherit (cfg) when;
         outputs = {
           effects = {
             flake-update = withSystem cfg.effect.system ({ config, pkgs, hci-effects, ... }:

--- a/effects/flake-update/test.nix
+++ b/effects/flake-update/test.nix
@@ -1,0 +1,156 @@
+{ effectVMTest, effects, hello, lib, mkEffect, runCommand, writeText }:
+
+let
+  
+in
+effectVMTest {
+  imports = [ ../testsupport/dns.nix ];
+  name = "flake-update";
+  nodes = {
+    gitea = { pkgs, ... }: {
+      services.gitea.enable = true;
+      services.gitea.settings.service.DISABLE_REGISTRATION = true;
+      # services.gitea.settings.log.LEVEL = "Trace";
+      # services.gitea.settings.databas.LOG_SQL = true;
+      services.gitea.settings.log.LEVEL = "Info";
+      services.gitea.settings.database.LOG_SQL = false;
+      networking.firewall.allowedTCPPorts = [ 3000 ];
+      environment.systemPackages = [ pkgs.gitea ];
+    };
+    client = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.git ];
+    };
+  };
+  defaults = { pkgs, ... }: {
+    environment.systemPackages = [ pkgs.jq ];
+  };
+  effects = {
+    update = effects.flakeUpdate {
+      gitRemote = "http://gitea:3000/test/repo";
+      user = "test";
+    };
+  };
+  secrets = {
+  };
+  
+  testScript = ''
+    start_all()
+    gitea.wait_for_unit("gitea.service")
+
+    gitea.succeed("""
+      su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea admin user create \
+        --username test --password test123 --email test@client'
+    """)
+
+    client.wait_for_unit("multi-user.target")
+    gitea.wait_for_open_port(3000)
+
+    token = gitea.succeed("""
+      curl --fail -X POST http://test:test123@gitea:3000/api/v1/users/test/tokens \
+        -H 'Accept: application/json' -H 'Content-Type: application/json' \
+        -d '{\"name\":\"token\"}' \
+        | jq -r '.sha1'
+    """).strip()
+
+    repo = client.succeed("""
+      curl -v --fail -X POST http://gitea:3000/api/v1/user/repos \
+        -H 'Accept: application/json' -H 'Content-Type: application/json' \
+        """ + f"-H 'Authorization: token {token}'" + """ \
+        -d '{"name":"repo", "private":true}'
+    """)
+    print(repo)
+
+    dep = client.succeed("""
+      curl -v --fail -X POST http://gitea:3000/api/v1/user/repos \
+        -H 'Accept: application/json' -H 'Content-Type: application/json' \
+        """ + f"-H 'Authorization: token {token}'" + """ \
+        -d '{"name":"dep", "private":true}'
+    """)
+    print(dep)
+
+    dep_commits = client.succeed("""
+    (
+    # set -x
+    echo "http://test:test123@gitea:3000" >~/.git-credentials
+    git config --global credential.helper store
+    git config --global user.email "test@client"
+    git config --global user.name "Test User"
+
+    git clone http://gitea:3000/test/dep.git
+    cd dep
+    touch file
+    git add file
+    git commit -m 'init'
+    git push
+    cd ..
+
+    git clone http://gitea:3000/test/repo.git
+    cd repo
+    cat >flake.nix <<EOF
+    {
+      inputs.dep = {
+        url = "git+http://gitea:3000/test/dep";
+        flake = false;
+      };
+      outputs = { ... }: {
+      };
+    }
+    EOF
+    ls -al
+    cat flake.nix
+    git add .
+    nix flake lock -v --extra-experimental-features nix-command\ flakes
+    git add .
+    git commit -m 'init'
+    git push
+    cd ..
+
+    cd dep
+    echo v2 >file
+    git add file
+    git commit -m 'init'
+    git push
+    git log --format=oneline
+    cd ..
+    ) 1>&2
+    (
+    cd dep
+    git log --format=%H
+    )
+    """).splitlines()
+
+    assert len(dep_commits) == 2
+
+    agent.succeed("echo test123 | effect-update")
+
+    repo_update_rev = client.succeed(f"""
+      (
+        set -x
+        cd repo
+        git fetch origin
+        git checkout flake-update
+        grep '{dep_commits[0]}' <flake.lock
+        git log 1>&2
+        git log | grep 'flake.lock: Update'
+        # The commit message mentions the hostname
+        git log | grep gitea
+        # The commit hashes occur in the message
+        # We only check for shortRev length, which is 7
+        git log | grep '{dep_commits[0][:7]}'
+        git log | grep '{dep_commits[1][:7]}'
+      ) 1>&2
+      (cd repo; git rev-parse HEAD)
+    """).rstrip()
+
+    with subtest("Idempotent and successful when up to date"):
+      agent.succeed("echo test123 | effect-update")
+      client.succeed(f"""
+        (
+          set -x
+          cd repo
+          git pull
+          [[ $(git rev-parse HEAD) == {repo_update_rev} ]]
+        )
+    """)
+  '';
+}

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -1,0 +1,57 @@
+top@{ withSystem, lib, inputs, config, ... }: {
+  imports = [
+    # dogfooding
+    ./flake-module.nix
+  ];
+  systems = [ "x86_64-linux" "aarch64-linux" ];
+  flake = {
+    # These aren't system dependent so we define them once. x86_64-linux is unrelated.
+    checks.x86_64-linux.evaluation-checks =
+      (import ./flake-modules/derivationTree-type.nix { inherit lib; }).tests
+        inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile;
+
+    tests = withSystem "x86_64-linux" ({ hci-effects, pkgs, ... }: {
+      git-crypt-hook = pkgs.callPackage ./effects/git-crypt-hook/test.nix { };
+      # pyjwt is marked insecure; skip
+      # nixops = pkgs.callPackage ./effects/nixops/test/default.nix {};
+      nix-shell = pkgs.callPackage ./effects/nix-shell/test.nix { };
+      nixops2 = pkgs.callPackage ./effects/nixops2/test/default.nix { nixpkgsFlake = inputs.nixpkgs; };
+      cachix-deploy = pkgs.callPackage ./effects/cachix-deploy/test.nix { };
+      mkEffect = pkgs.callPackage ./effects/effect/test.nix { };
+      nixos = hci-effects.callPackage ./effects/nixos/test.nix { };
+    });
+  };
+
+  herculesCI = { config, ... }: {
+
+    # We don't have kvm on arm in CI for now.
+    ciSystems = [ "x86_64-linux" ];
+
+    onPush.default = {
+      outputs.effects =
+        let
+          pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
+        in
+        {
+          tests = top.config.flake.tests // {
+            netlifyDeploy = pkgs.callPackage ./effects/netlify/test/default.nix { inherit (config.repo) rev; };
+          };
+        };
+    };
+  };
+
+  perSystem = { pkgs, hci-effects, inputs', ... }: {
+    checks = {
+      flake-update = hci-effects.callPackage ./effects/flake-update/test.nix { };
+      ssh = hci-effects.callPackage ./effects/ssh/test.nix { };
+    };
+    devShells.default = pkgs.mkShell {
+      nativeBuildInputs = [ pkgs.nixpkgs-fmt pkgs.hci ];
+    };
+ 
+    # Quick and dirty // override. Do not recommend.
+    herculesCIEffects.pkgs = pkgs // {
+      hci = inputs'.hercules-ci-agent.packages.hercules-ci-cli;
+    };
+  };
+}

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,0 +1,8 @@
+{
+  imports = [
+    ./flake-modules/module-argument.nix
+    ./flake-modules/herculesCI-attribute.nix
+    ./flake-modules/herculesCI-helpers.nix
+    ./effects/flake-update/flake-module.nix
+  ];
+}

--- a/flake-modules/derivationTree-type.nix
+++ b/flake-modules/derivationTree-type.nix
@@ -1,0 +1,72 @@
+{ lib }:
+let
+  inherit (lib) types;
+  inherit (types) package oneOf lazyAttrsOf bool raw enum;
+
+  derivationTree =
+    oneOf [
+      package
+      (lazyTraversedAttrs { recurseByDefault = true; } derivationTree)
+      bool  # allows recurseForDerivations to merge
+      (enum [null])
+      raw
+    ] // { description = "a tree of attribute sets and derivations"; };
+  lazyTraversedAttrs = { recurseByDefault }: t:
+    let o = lazyAttrsOf t;
+    in o // {
+      check = v: o.check v && v.recurseForDerivations or recurseByDefault;
+    };
+
+  merge = t: vs:
+    t.merge
+      [ "test" "location" ]
+      (lib.imap
+        (i: v: { value = v; file = "test value number ${toString i}"; })
+        vs);
+
+  pkg = name:
+    { type = "derivation"; outPath = builtins.toFile "${name}" ""; drvPath = builtins.toFile "${name}-drv" "kind of"; };
+
+  ex1 = [
+    { a = pkg "a"; }
+    { b = pkg "b"; }
+  ];
+  ex2 = [
+    { n.a = pkg "a"; }
+    { n.b = pkg "b"; }
+  ];
+  ex2_1 = [
+    { n = lib.recurseIntoAttrs { a = pkg "a"; }; }
+    { n = lib.recurseIntoAttrs { b = pkg "b"; }; }
+  ];
+  ex2_2 = [
+    { n = { a = pkg "a"; c = null; }; }
+    { n = { b = pkg "b"; c = null; }; }
+  ];
+  ex2_3 = [
+    { n = { a = pkg "a"; c = {}; }; }
+    { n = { b = pkg "b"; c = {}; }; }
+  ];
+  ex3 = [
+    # dontRecurseIntoAttrs could contain any kind of attribute set, so we can't merge this.
+    { n = lib.dontRecurseIntoAttrs { a = 1; }; }
+    { n = lib.dontRecurseIntoAttrs { b = 10; }; }
+  ];
+
+  traceId = x: builtins.trace x x;
+  inherit (builtins) tryEval;
+  fail = x: !(tryEval (traceId x)).success;
+
+  tests = done:
+    assert merge derivationTree ex1 == { a = pkg "a"; b = pkg "b"; };
+    assert (merge derivationTree ex2).n == { a = pkg "a"; b = pkg "b"; };
+    assert (merge derivationTree ex2_1).n == lib.recurseIntoAttrs { a = pkg "a"; b = pkg "b"; };
+    assert (merge derivationTree ex2_2).n == { a = pkg "a"; b = pkg "b"; c = null; };
+    assert (merge derivationTree ex2_3).n == { a = pkg "a"; b = pkg "b"; c = {}; };
+    assert fail (merge derivationTree ex3).n;
+    done;
+
+in
+{
+  inherit derivationTree tests;
+}

--- a/flake-modules/herculesCI-attribute.nix
+++ b/flake-modules/herculesCI-attribute.nix
@@ -1,0 +1,285 @@
+flakeParts@{ lib, config, self, ... }:
+let
+  inherit (lib)
+    types
+    mkOption
+    ;
+
+  default-hci-for-flake = import ../vendor/hercules-ci-agent/default-herculesCI-for-flake.nix;
+
+  repoModule = {
+    options = {
+      ref = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          The git "ref" of the checkout.
+        '';
+        example = "refs/heads/main";
+      };
+      branch = mkOption {
+        type = types.nullOr types.str;
+        readOnly = true;
+        description = ''
+          The branch of the checkout. `null` when not on a branch; e.g. when on a tag.
+        '';
+        example = "main";
+      };
+      tag = mkOption {
+        type = types.nullOr types.str;
+        readOnly = true;
+        description = ''
+          The tag of the checkout. `null` when not on a tag; e.g. when on a branch.
+        '';
+        example = "1.0";
+      };
+      rev = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          The git revision, also known as the commit hash.
+        '';
+        example = "17ae1f614017447a983c34bb046892b3c571df52";
+      };
+      shortRev = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          An abbreviated `rev`.
+        '';
+        example = "17ae1f6";
+      };
+      remoteHttpUrl = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          HTTP url for cloning the repository.
+
+          _Since hercules-ci-agent 0.9.8_
+        '';
+      };
+      remoteSshUrl = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          SSH url for cloning the repository.
+
+          _Since hercules-ci-agent 0.9.8_
+        '';
+      };
+      webUrl = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          A URL to open the repository in the browser.
+
+          _Since hercules-ci-agent 0.9.8_
+        '';
+      };
+      forgeType = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          What forge implementation hosts the repository.
+
+          E.g. "github" or "gitlab"
+
+          _Since hercules-ci-agent 0.9.8_
+        '';
+        example = "github";
+      };
+      owner = mkOption {
+        type = types.str;
+        description = ''
+          The owner of the repository.
+
+          _Since hercules-ci-agent 0.9.8_
+        '';
+        readOnly = true;
+      };
+      name = mkOption {
+        type = types.str;
+        description = ''
+          The name of the repository.
+
+          _Since hercules-ci-agent 0.9.8_
+        '';
+        readOnly = true;
+      };
+    };
+  };
+
+  # FIXME
+  outputsType = types.raw;
+
+  outputsModule = { ... }: {
+    options = {
+      outputs = mkOption {
+        type = outputsType;
+        description = ''
+          A collection of builds and effects. These may be nested recursively into attribute sets.
+
+          Hercules CI's traversal of nested sets can be cancelled with `lib.dontRecurseIntoAttrs`.
+
+          See the parent option for details about when the job runs.
+        '';
+      };
+    };
+  };
+
+  onPushModule = { ... }: {
+    imports = [ outputsModule ];
+  };
+
+  onScheduleModule = { ... }: {
+    imports = [ outputsModule ];
+    options = {
+      when = {
+        minute = mkOption {
+          type = types.nullOr (types.ints.between 0 59);
+          default = null;
+          description = ''
+            An optional integer representing the minute mark at which a job should be created.
+            
+            The default value `null` represents an arbitrary minute.
+          '';
+        };
+        hour = mkOption {
+          type = types.nullOr (coercedToList (types.ints.between 0 23));
+          default = null;
+          description = ''
+            An optional integer representing the hours at which a job should be created.
+            
+            The default value `null` represents an arbitrary hour.
+          '';
+        };
+        dayOfWeek = mkOption {
+          type = types.nullOr (types.enum ["Mon" "Tue" "Wed" "Thu" "Fri" "Sat" "Sun"]);
+          default = null;
+          description = ''
+            An optional list of week days during which to create a job.
+
+            The default value `null` represents all days.
+          '';
+        };
+        dayOfMonth = mkOption {
+          type = types.nullOr (coercedToList (types.ints.between 0 31));
+          default = null;
+          description = ''
+            An optional list of day of the month during which to create a job.
+
+            The default value `null` represents all days.
+          '';
+        };
+      };
+    };
+  };
+
+  coercedToList = t: types.coercedTo t (x: [x]) (types.listOf t);
+
+  herculesCIModule = { config, ... }: {
+    options = {
+      repo = mkOption {
+        type = types.submodule repoModule;
+        readOnly = true;
+        description = ''
+          The repository and checkout metadata of the current checkout, provided by Hercules CI.
+          These options are read-only.
+
+          You may read options by querying the `config` module argument.
+        '';
+      };
+      out = mkOption {
+        type = types.lazyAttrsOf types.raw;
+        internal = true;
+        description = ''
+          The return value of the `herculesCI` function in the flake.
+          All attributes in this return value should be represented by options
+          that write to this internal option.
+        '';
+      };
+      onPush = mkOption {
+        type = types.lazyAttrsOf (types.submoduleWith { modules = [ onPushModule ]; });
+        description = ''
+          This declares what to do when a Git ref is updated, such as when you push a commit or after you merge a pull request.
+
+          By default `onPush.default` defines a job that builds the known flake output attributes.
+          It can be disabled by setting `onPush.default.enable = false;`.
+
+          The name of the job (from `onPush.<name>`) will be used as part of the commit status of the resulting job.
+        '';
+        default = {};
+      };
+      onSchedule = mkOption {
+        type = types.lazyAttrsOf (types.submoduleWith { modules = [ onScheduleModule ]; });
+        description = ''
+          _Since hercules-ci-agent 0.9.8_
+
+          Behaves similar to onPush, but is responsible for jobs that respond to the passing of time rather than to a git push or equivalent.
+        '';
+        default = {};
+      };
+      ciSystems = mkOption {
+        type = types.listOf types.str;
+        default = flakeParts.config.systems;
+        defaultText = lib.literalExpressions "config.systems  # from flake parts";
+      };
+    };
+    config = {
+      onPush.default.outputs =
+        default-hci-for-flake.flakeToOutputs
+          self
+          { ciSystems = lib.genAttrs config.ciSystems (system: {}); };
+      out = {
+        inherit (config) onPush onSchedule ciSystems;
+      };
+    };
+  };
+
+in
+{
+
+  options = {
+    herculesCI = mkOption {
+      type = types.deferredModuleWith { staticModules = [ herculesCIModule ]; };
+      description = ''
+        Hercules CI environment and configuration. See the sub-options for details.
+
+        Regarding the implementation: Hercules CI offers a bit more information than flakes by itself, and does so by calling the `herculesCI` attribute on the flake.
+        The purpose of the top-level `herculesCI` option in the flake-parts module is to facilitate define this function using declared options.
+      '';
+    };
+  };
+
+  config = {
+    flake.herculesCI = {
+      # These are lazy errors in order to allow some exploration in nix repl.
+      # hci repl: https://github.com/hercules-ci/hercules-ci-agent/issues/459
+      herculesCI ? throw "`<flake>.outputs.herculesCI` requires an `herculesCI` argument.",
+      primaryRepo ? throw "`<flake>.outputs.primaryRepo` requires a `primaryRepo` argument.",
+      ... }:
+      let
+        paramModule = {
+          _file = "herculesCI parameters";
+          config = {
+            # Filter out values which are unavailable and therefore null.
+            # e.g. hci effect run may not support owner and name.
+            # Always be careful when filtering, because it's not as lazy as you'd like.
+            # Shouldn't be a problem here though.
+            repo = lib.filterAttrs (k: v: v != null) {
+              inherit (primaryRepo) ref branch tag rev shortRev;
+              remoteHttpUrl = primaryRepo.remoteHttpUrl or (throw "repo.remoteHttpUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an http(s) URL.");
+              remoteSshUrl = primaryRepo.remoteSshUrl or (throw "repo.remoteHttpUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an ssh URL.");
+              webUrl = primaryRepo.webUrl or (throw "repo.webUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an http URL.");
+              forgeType = primaryRepo.forgeType or (throw "repo.forgeType requires hercules-ci-agent >=0.9.8.");
+              owner = primaryRepo.owner or (throw "repo.owner requires hercules-ci-agent >=0.9.8.");
+              name = primaryRepo.name or (throw "repo.name requires hercules-ci-agent >=0.9.8.");
+            };
+          };
+        };
+        eval = lib.evalModules { modules = [ paramModule config.herculesCI ]; };
+      in
+        eval.config.out;
+  };
+
+}

--- a/flake-modules/herculesCI-attribute.nix
+++ b/flake-modules/herculesCI-attribute.nix
@@ -6,6 +6,7 @@ let
     ;
 
   default-hci-for-flake = import ../vendor/hercules-ci-agent/default-herculesCI-for-flake.nix;
+  inherit (import ./derivationTree-type.nix { inherit lib; }) derivationTree;
 
   repoModule = {
     options = {
@@ -109,13 +110,10 @@ let
     };
   };
 
-  # FIXME
-  outputsType = types.raw;
-
   outputsModule = { ... }: {
     options = {
       outputs = mkOption {
-        type = outputsType;
+        type = derivationTree;
         description = ''
           A collection of builds and effects. These may be nested recursively into attribute sets.
 

--- a/flake-modules/herculesCI-attribute.nix
+++ b/flake-modules/herculesCI-attribute.nix
@@ -58,6 +58,8 @@ let
 
           _Since hercules-ci-agent 0.9.8_
         '';
+        defaultText = lib.literalMD "";
+        default = throw "repo.remoteHttpUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an http(s) URL.";
       };
       remoteSshUrl = mkOption {
         type = types.str;
@@ -67,6 +69,8 @@ let
 
           _Since hercules-ci-agent 0.9.8_
         '';
+        defaultText = lib.literalMD "";
+        default = throw "repo.remoteHttpUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an ssh URL.";
       };
       webUrl = mkOption {
         type = types.str;
@@ -76,6 +80,8 @@ let
 
           _Since hercules-ci-agent 0.9.8_
         '';
+        defaultText = lib.literalMD "";
+        default = throw "repo.webUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an http URL.";
       };
       forgeType = mkOption {
         type = types.str;
@@ -88,6 +94,8 @@ let
           _Since hercules-ci-agent 0.9.8_
         '';
         example = "github";
+        defaultText = lib.literalMD "";
+        default = throw "repo.forgeType requires hercules-ci-agent >=0.9.8.";
       };
       owner = mkOption {
         type = types.str;
@@ -97,6 +105,8 @@ let
           _Since hercules-ci-agent 0.9.8_
         '';
         readOnly = true;
+        defaultText = lib.literalMD "";
+        default = throw "repo.owner requires hercules-ci-agent >=0.9.8.";
       };
       name = mkOption {
         type = types.str;
@@ -106,6 +116,8 @@ let
           _Since hercules-ci-agent 0.9.8_
         '';
         readOnly = true;
+        defaultText = lib.literalMD "";
+        default = throw "repo.name requires hercules-ci-agent >=0.9.8.";
       };
     };
   };
@@ -266,12 +278,12 @@ in
             # Shouldn't be a problem here though.
             repo = lib.filterAttrs (k: v: v != null) {
               inherit (primaryRepo) ref branch tag rev shortRev;
-              remoteHttpUrl = primaryRepo.remoteHttpUrl or (throw "repo.remoteHttpUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an http(s) URL.");
-              remoteSshUrl = primaryRepo.remoteSshUrl or (throw "repo.remoteHttpUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an ssh URL.");
-              webUrl = primaryRepo.webUrl or (throw "repo.webUrl requires hercules-ci-agent >=0.9.8. If you run hci effect run, make sure your repository remote has an http URL.");
-              forgeType = primaryRepo.forgeType or (throw "repo.forgeType requires hercules-ci-agent >=0.9.8.");
-              owner = primaryRepo.owner or (throw "repo.owner requires hercules-ci-agent >=0.9.8.");
-              name = primaryRepo.name or (throw "repo.name requires hercules-ci-agent >=0.9.8.");
+              remoteHttpUrl = primaryRepo.remoteHttpUrl or null;
+              remoteSshUrl = primaryRepo.remoteSshUrl or null;
+              webUrl = primaryRepo.webUrl or null;
+              forgeType = primaryRepo.forgeType or null;
+              owner = primaryRepo.owner or null;
+              name = primaryRepo.name or null;
             };
           };
         };

--- a/flake-modules/herculesCI-helpers.nix
+++ b/flake-modules/herculesCI-helpers.nix
@@ -1,0 +1,33 @@
+flakeParts@{ lib, config, self, ... }:
+let
+  inherit (lib)
+    types
+    mkOption
+    ;
+
+  herculesCIModule = { config, ... }: {
+    config = {
+      out = {
+        _debug = config;
+      };
+    };
+  };
+
+in
+{
+
+  options = {
+    herculesCI = mkOption {
+      type = types.deferredModuleWith { staticModules = [ herculesCIModule ]; };
+    };
+
+    defaultEffectSystem = mkOption {
+      type = types.str;
+      default = "x86_64-linux";
+      description = ''
+        The default system type that some integrations will use to run their effects on.
+      '';
+    };
+  };
+
+}

--- a/flake-modules/module-argument.nix
+++ b/flake-modules/module-argument.nix
@@ -11,7 +11,7 @@ in
 {
   options = {
     perSystem = mkPerSystemOption ({ config, pkgs, ... }: {
-      _file = ./flake-module.nix;
+      _file = ./module-argument.nix;
       options = {
         herculesCIEffects.pkgs = mkOption {
           type = types.raw or types.unspecified;
@@ -26,7 +26,7 @@ in
       };
       config = {
         _module.args.effects =
-          let effects = import ./effects/default.nix effects config.herculesCIEffects.pkgs;
+          let effects = import ../effects/default.nix effects config.herculesCIEffects.pkgs;
           in effects;
       };
     });

--- a/flake-modules/module-argument.nix
+++ b/flake-modules/module-argument.nix
@@ -10,7 +10,11 @@ let
 in
 {
   options = {
-    perSystem = mkPerSystemOption ({ config, pkgs, ... }: {
+    perSystem = mkPerSystemOption ({ config, pkgs, ... }:
+    let
+      hci-effects = import ../effects/default.nix hci-effects config.herculesCIEffects.pkgs;
+    in
+    {
       _file = ./module-argument.nix;
       options = {
         herculesCIEffects.pkgs = mkOption {
@@ -25,9 +29,8 @@ in
         };
       };
       config = {
-        _module.args.effects =
-          let effects = import ../effects/default.nix effects config.herculesCIEffects.pkgs;
-          in effects;
+        _module.args.effects = lib.warn "The effects module argument has been renamed to hci-effects." hci-effects;
+        _module.args.hci-effects = hci-effects;
       };
     });
   };

--- a/flake-public-outputs.nix
+++ b/flake-public-outputs.nix
@@ -1,0 +1,27 @@
+{ withSystem, inputs, ... }: {
+  imports = [ ./flake-module.nix ];
+  systems = [ "x86_64-linux" "aarch64-linux" ];
+  flake = {
+
+    flakeModule = ./flake-module.nix;
+
+    lib.withPkgs = pkgs:
+      let effects = import ./effects/default.nix effects pkgs;
+      in effects;
+
+    overlay = final: prev: {
+      effects = import ./effects/default.nix final.effects final;
+    };
+
+    templates = rec {
+      default = flake-parts;
+      flake-parts = {
+        path = ./templates/flake-parts;
+        description = ''
+          A demonstration of how to integrate effects with https://flake.parts.
+        '';
+      };
+    };
+
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,6 +2,23 @@
   "nodes": {
     "flake-parts": {
       "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1666885127,
+        "narHash": "sha256-uXA/3lhLhwOTBMn9a5zJODKqaRT+SuL5cpEmOz2ULoo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0e101dbae756d35a376a5e1faea532608e4a4b9a",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
         "nixpkgs": [
           "hercules-ci-agent",
           "nixpkgs"
@@ -38,7 +55,7 @@
     },
     "hercules-ci-agent": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix"
@@ -94,6 +111,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1664384182,
@@ -134,6 +169,7 @@
     },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "hercules-ci-agent": "hercules-ci-agent",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,100 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs": [
+          "hercules-ci-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1657102481,
+        "narHash": "sha256-62Fuw8JgPub38OdgNefkIKOodM9nC3M0AG6lS+7smf4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "608ed3502263d6f4f886d75c48fc2b444a4ab8d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hercules-ci-agent": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix"
+      },
+      "locked": {
+        "lastModified": 1668032598,
+        "narHash": "sha256-KJF0ULd33lLOQVO26Ea1NKObSi9DIUfaxXducaKKpec=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-agent",
+        "rev": "58954ab190bbc27a9d5149ebdafbf80851476461",
+        "type": "github"
+      },
+      "original": {
+        "id": "hercules-ci-agent",
+        "ref": "on-schedule",
+        "type": "indirect"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "hercules-ci-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1657835815,
+        "narHash": "sha256-CnZszAYpNKydh6N7+xg+eRtWNVoAAGqc6bg+Lpgq1xc=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "54a24f042f93c79f5679f133faddedec61955cf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1660305968,
+        "narHash": "sha256-r0X1pZCSEA6mzt5OuTA7nHuLmvnbkwgpFAh1iLIx4GU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c4a0efdd5a728e20791b8d8d2f26f90ac228ee8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1664384182,
         "narHash": "sha256-RM7C+6c9oSeZuoCCXOCRZUI1o4wpLo6pmOz1PxMN1ig=",
@@ -15,9 +109,33 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "hercules-ci-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1653840245,
+        "narHash": "sha256-6bqmsp5r+Ct7Il09M40WeRDBhjmUe56RhIT0RZPY+NE=",
+        "owner": "hercules-ci",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "596dac761042d9ba90a507d43ad506cb952c984d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "ref": "flakeModule",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "hercules-ci-agent": "hercules-ci-agent",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,8 @@
     flakeModule = {
       imports = [
         ./flake-modules/module-argument.nix
+        ./flake-modules/herculesCI-attribute.nix
+        ./flake-modules/herculesCI-helpers.nix
       ];
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
         ssh = effects.callPackage ./effects/ssh/test.nix {};
         nixos = effects.callPackage ./effects/nixos/test.nix {};
       };
+    checks.x86_64-linux.evaluation-checks =
+      (import ./flake-modules/derivationTree-type.nix { inherit (nixpkgs) lib; }).tests nixpkgs.legacyPackages.x86_64-linux.emptyFile;
 
     herculesCI = { rev, branch, ... }: {
       onPush.default = {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,11 @@
 
   outputs = { self, nixpkgs, ... }: {
 
-    flakeModule = ./flake-module.nix;
+    flakeModule = {
+      imports = [
+        ./flake-modules/module-argument.nix
+      ];
+    };
 
     lib.withPkgs = pkgs:
       let effects = import ./effects/default.nix effects pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -4,73 +4,12 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
   inputs.hercules-ci-agent.url = "hercules-ci-agent/on-schedule";
 
-  outputs = { self, nixpkgs, hercules-ci-agent, ... }: {
-
-    flakeModule = {
-      imports = [
-        ./flake-modules/module-argument.nix
-        ./flake-modules/herculesCI-attribute.nix
-        ./flake-modules/herculesCI-helpers.nix
-        ./effects/flake-update/flake-module.nix
-      ];
-    };
-
-    lib.withPkgs = pkgs:
-      let effects = import ./effects/default.nix effects (pkgs // { hci = hercules-ci-agent.packages.x86_64-linux.hercules-ci-cli; });
-      in effects;
-
-    overlay = final: prev: {
-      effects = import ./effects/default.nix final.effects final;
-    };
-
-    # TODO: add tests as checks by flattening
-    tests =
-      let
-        pkgs = nixpkgs.legacyPackages.x86_64-linux;
-        effects = self.lib.withPkgs pkgs;
-      in {
-        flake-update = effects.callPackage ./effects/flake-update/test.nix {};
-        git-crypt-hook = pkgs.callPackage ./effects/git-crypt-hook/test.nix {};
-        # pyjwt is marked insecure; skip
-        # nixops = pkgs.callPackage ./effects/nixops/test/default.nix {};
-        nix-shell = pkgs.callPackage ./effects/nix-shell/test.nix {};
-        nixops2 = pkgs.callPackage ./effects/nixops2/test/default.nix { nixpkgsFlake = nixpkgs; };
-        cachix-deploy = pkgs.callPackage ./effects/cachix-deploy/test.nix {};
-        mkEffect = pkgs.callPackage ./effects/effect/test.nix {};
-        ssh = effects.callPackage ./effects/ssh/test.nix {};
-        nixos = effects.callPackage ./effects/nixos/test.nix {};
-      };
-    checks.x86_64-linux.evaluation-checks =
-      (import ./flake-modules/derivationTree-type.nix { inherit (nixpkgs) lib; }).tests nixpkgs.legacyPackages.x86_64-linux.emptyFile;
-
-    herculesCI = { rev, branch, ... }: {
-      onPush.default = {
-        outputs.effects = let
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
-        in {
-          tests = self.tests // {
-            netlifyDeploy = pkgs.callPackage ./effects/netlify/test/default.nix { inherit rev; };
-          };
-        };
-      };
-    };
-
-    devShells.x86_64-linux.default =
-      let pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      in
-      pkgs.mkShell {
-        nativeBuildInputs = [ pkgs.nixpkgs-fmt pkgs.hci ];
-      };
-
-    templates = rec {
-      default = flake-parts;
-      flake-parts = {
-        path = ./templates/flake-parts;
-        description = ''
-          A demonstration of how to integrate effects with https://flake.parts.
-        '';
-      };
-    };
-
-  };
+  outputs = { self, nixpkgs, hercules-ci-agent, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit self; }
+      ({ withSystem, ... }: {
+        imports = [
+          ./flake-public-outputs.nix
+          ./flake-dev.nix
+        ];
+      });
 }

--- a/vendor/hercules-ci-agent/default-herculesCI-for-flake.nix
+++ b/vendor/hercules-ci-agent/default-herculesCI-for-flake.nix
@@ -1,0 +1,156 @@
+/*
+  Helper functions for working with flakes.
+
+  Schema: DefaultHerculesCIHelperSchema
+*/
+let
+  inherit (builtins)
+    attrNames
+    concatMap
+    hasAttr
+    intersectAttrs
+    listToAttrs
+    mapAttrs
+    ;
+
+  # lib
+  nameValuePair = k: v: { name = k; value = v; };
+  filterAttrs = pred: set:
+    listToAttrs (
+      concatMap
+        (name: let v = set.${name}; in if pred name v then [ (nameValuePair name v) ] else [ ])
+        (attrNames set)
+    );
+  optionalAttrs = b: if b then a: a else _: { };
+  optionalCall = f: a: if builtins.isFunction f then f a else f;
+  # end lib
+
+  # flake -> evalArgs -> { flake | herculesCI }
+  addDefaults = flake: evalArgs:
+    let
+      args = evalArgs // {
+        ciSystems =
+          if flake?herculesCI.ciSystems
+          then listToAttrs (map (sys: nameValuePair sys { }) flake.herculesCI.ciSystems)
+          else args.herculesCI.ciSystems;
+      };
+      herculesCI = optionalCall (flake.herculesCI or { }) evalArgs;
+    in
+    herculesCI // optionalAttrs (!herculesCI?onPush) {
+      onPush.default = {
+        outputs = flakeToOutputs flake args;
+      };
+    };
+
+  flakeToOutputs = flake: args: mapAttrs (translateFlakeAttr args) flake.outputs;
+
+  filterSystems = ciSystems:
+    if ciSystems == null
+    then attrs: attrs
+    else intersectAttrs ciSystems;
+
+  isEnabledSystemConfig = ciSystems:
+    if ciSystems == null
+    then sys: true
+    else
+      sys:
+      hasAttr sys.config.nixpkgs.localSystem.system ciSystems
+      || hasAttr sys.config.nixpkgs.system ciSystems;
+
+  filterSystemConfigs = ciSystems: filterAttrs (k: v:
+    if isEnabledSystemConfig ciSystems v
+    then true
+    else builtins.trace "Ignoring flake attribute ${k} (system not in ciSystems)" false);
+
+  translateFlakeAttr = args: k: v:
+    if translations?${k}
+    then translations.${k} args v
+    else if deprecated?${k}
+    then builtins.trace "Ignoring flake attribute ${k} (deprecated)" null
+    else builtins.trace "Ignoring flake attribute ${k}" null;
+
+  deprecated = {
+    defaultApp = null;
+    defaultPackage = null;
+    defaultTemplate = null;
+    defaultBundler = null;
+    overlay = null;
+    # too soon?
+    # devShell = null;
+  };
+
+  checkApp = app:
+    if app.type != "app"
+    then throw "App type attribute must be set to \"app\"."
+    else if builtins.typeOf app.program == "string"
+    then {
+      program = validateProgramFromStringContext app.program;
+    }
+    else {
+      inherit (app) program;
+    };
+
+  validateProgramFromStringContext = s:
+    let
+      ctx = builtins.getContext s;
+      drvs = builtins.attrNames ctx;
+      drvPath =
+        if drvs == [ ]
+        then throw "The provided program string does not have a package in its context. Please set the app's program attribute to a package with `meta.mainProgram` or to a string of the form \"\${pkg}/bin/command\", where `pkg` is a package."
+        else if builtins.length drvs != 1
+        then throw "The provided program string has multiple packages in its context. Please set the app's program attribute to a single package with `meta.mainProgram` or to a string of the form \"\${pkg}/bin/command\", where `pkg` is a single package."
+        else builtins.head drvs;
+      basename = baseNameOf drvPath;
+      hashLength = 33;
+      l = builtins.stringLength basename;
+    in
+    {
+      name = builtins.substring hashLength (l - hashLength - 4) basename;
+      type = "derivation";
+      drvPath = drvPath;
+    };
+
+  translateShell = drv:
+    if drv.type or null != "derivation"
+    then throw "Attribute is not a shell derivation"
+    else drv // { buildDependenciesOnly = true; };
+
+  translations =
+    let
+      ignore = args: x: null;
+      same = args: x: x;
+      forSystems = f: args: attrs: mapAttrs f (filterSystems args.ciSystems attrs);
+    in
+    rec {
+      # TODO validate
+
+      # buildable
+      packages = forSystems (sys: pkgs: pkgs);
+      checks = forSystems (sys: checks: checks);
+      devShell = forSystems (sys: translateShell);
+      devShells = forSystems (sys: mapAttrs (k: translateShell));
+      apps = forSystems (sys: mapAttrs (k: checkApp));
+      nixosConfigurations = args: attrs: mapAttrs (k: sys: { config.system.build.toplevel = sys.config.system.build.toplevel; }) (filterSystemConfigs args.ciSystems attrs);
+      darwinConfigurations = args: attrs: mapAttrs (k: sys: { config.system.build.toplevel = sys.config.system.build.toplevel; }) (filterSystemConfigs args.ciSystems attrs);
+      effects = args: effects:
+        if builtins.isAttrs effects
+        then effects
+        else effects args;
+
+      # not buildable
+      herculesCI = ignore;
+      overlays = ignore;
+      submodules = ignore;
+      nixosModules = ignore;
+      darwinModules = ignore;
+      legacyPackages = ignore;
+
+    };
+
+in
+{
+  inherit
+    addDefaults
+    flakeToOutputs
+    ;
+}


### PR DESCRIPTION
 - Stripped down, cleaned up version of https://github.com/hercules-ci/hercules-ci-effects/pull/85
 - `herculesCI.onPush` etc attributes
 - flake.parts module
 - needs upcoming agent release and backend update (so doesn't run on hercules-ci.com yet)
 - relies on deleting the `flake-update` branch a lot now. Can be improved later.

```
        imports = [
          inputs.hercules-ci-effects.flakeModule
        ];
        flake-update.enable = true;
```