### PR TITLE
`gitWriteBranch` and more

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -8,6 +8,7 @@
 ** xref:guide/deploy-a-nixops-network.adoc[Deploy a NixOps network]
 ** xref:guide/configure-git-crypt.adoc[Configure git-crypt]
 ** xref:guide/write-a-custom-effect.adoc[Write a Custom Effect]
+** xref:guide/deploy-to-github-pages.adoc[Deploy to GitHub Pages]
 * Effect Module Reference
 ** xref:reference/effect-modules/core.adoc[Core Options]
 ** xref:reference/effect-modules/git.adoc[Git Options]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -10,6 +10,7 @@
 ** xref:guide/write-a-custom-effect.adoc[Write a Custom Effect]
 * Effect Module Reference
 ** xref:reference/effect-modules/core.adoc[Core Options]
+** xref:reference/effect-modules/git.adoc[Git Options]
 * Flake Parts Module Reference
 ** xref:reference/flake-parts/flake-update.adoc[`flake-update`]
 * Nix Functions Reference

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -23,6 +23,7 @@
 ** xref:reference/nix-functions/ssh.adoc[`ssh`]
 ** _Deployment Functions_
 ** xref:reference/nix-functions/netlifyDeploy.adoc[`netlifyDeploy`]
+** xref:reference/nix-functions/gitWriteBranch.adoc[`gitWriteBranch`]
 ** xref:reference/nix-functions/runArion.adoc[`runArion`]
 ** xref:reference/nix-functions/runCachixDeploy.adoc[`runCachixDeploy`]
 ** xref:reference/nix-functions/runNixDarwin.adoc[`runNixDarwin`]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -14,6 +14,7 @@
 ** xref:reference/effect-modules/git.adoc[Git Options]
 * Flake Parts Module Reference
 ** xref:reference/flake-parts/flake-update.adoc[`flake-update`]
+** xref:reference/flake-parts/github-pages.adoc[`github-pages`]
 * Nix Functions Reference
 ** _General Functions_
 ** xref:reference/nix-functions/mkEffect.adoc[`mkEffect`]

--- a/docs/modules/ROOT/pages/guide/deploy-to-github-pages.adoc
+++ b/docs/modules/ROOT/pages/guide/deploy-to-github-pages.adoc
@@ -1,0 +1,90 @@
+
+= Deploy documentation to GitHub Pages with Nix
+
+This guide will show you how you can deploy packaged documentation when `master` is updated.
+
+Prerequisites:
+
+ - You have xref:master@hercules-ci:ROOT:getting-started/index.adoc[set up an agent] for the account that owns the repository
+ - You have packaged your documentation somewhere in a derivation output
+ - You have added the repository to your Hercules CI installation
+
+== With flake-parts
+
+1. https://flake.parts/options/hercules-ci-effects.html#installation:[Add] `hercules-ci-effects.flakeModule` to your top level flake-parts imports.
+2. Specify the your main branch or release branch name in `hercules-ci.github-pages.branch`.
+3. Specify the path to your documentation site in `perSystem.hercules-ci.github-pages.settings.contents`.
+
+You may now push your feature branch. Hercules CI and the `hercules-ci-effects` code will check that the effect is buildable. When you merge the branch, the `onPush.default` job will trigger a GitHub Pages deployment when all the builds succeed.
+
+Example `flake.nix`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        inputs.hercules-ci-effects.flakeModule
+      ];
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+
+      hercules-ci.github-pages.branch = "main";
+
+      perSystem = { config, pkgs, ... }: {
+        packages.default = pkgs.nix.doc;
+        hercules-ci.github-pages.settings.contents = config.packages.default + "/share/doc/nix/manual";
+      };
+    };
+}
+```
+
+== Without flake-parts
+
+Flake-parts is recommended, but with xref:guide/import-or-pin.adoc#mkHerculesCI[`mkHerculesCI`] you don't have to write your entire flake with flake-parts.
+
+Let's skip to the example:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+  };
+
+  outputs = inputs@{ nixpkgs, ... }:
+    {
+      packages = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"] (system: {
+        default = nixpkgs.legacyPackages.${system}.nix.doc;
+      });
+
+      herculesCI = inputs.hercules-ci-effects.lib.mkHerculesCI { inherit inputs; } {
+        # Values for flake-parts options may be written here, including
+        # non-Hercules-CI options, but those will only take affect in CI and the `hci`
+        # command. See
+        # https://docs.hercules-ci.com/hercules-ci-effects/guide/import-or-pin.html#mkHerculesCI
+
+        herculesCI = {
+          ciSystems = [ "x86_64-linux" "aarch64-darwin" ];
+        };
+
+        hercules-ci.github-pages.branch = "main";
+        perSystem = { config, self', inputs', system, ... }: {
+          hercules-ci.github-pages.settings.contents = self'.packages.default + "/share/doc/nix/manual";
+        };
+      };
+    };
+}
+```
+
+In your own flake, make sure that the `herculesCI` flake output attribute is actually at the top level, and not in a place where it is duplicated for each system.
+
+== More
+
+* This effect is implemented as a module that calls xref:reference/nix-functions/gitWriteBranch.adoc[`gitWriteBranch`]. It provides some options for further customization.
+
+* See https://flake.parts/options/hercules-ci-effects.html#opt-hercules-ci.github-pages.branch[`hercules-ci.github-pages.branch`] in the flake-parts reference documentation. You may find a few file:///home/user/h/flake.parts-website/result/options/hercules-ci-effects.html#options[other options] there as well.

--- a/docs/modules/ROOT/pages/guide/deploy-to-github-pages.adoc
+++ b/docs/modules/ROOT/pages/guide/deploy-to-github-pages.adoc
@@ -1,12 +1,12 @@
 
-= Deploy documentation to GitHub Pages with Nix
+= Deploy a static website to GitHub Pages with Nix
 
-This guide will show you how you can deploy packaged documentation when `master` is updated.
+This guide will show you how you can deploy for example packaged documentation whenever the `master` branch is updated.
 
 Prerequisites:
 
  - You have xref:master@hercules-ci:ROOT:getting-started/index.adoc[set up an agent] for the account that owns the repository
- - You have packaged your documentation somewhere in a derivation output
+ - You have packaged a static site or documentation in a derivation output or possibly a subpath of the output
  - You have added the repository to your Hercules CI installation
 
 == With flake-parts

--- a/docs/modules/ROOT/pages/guide/import-or-pin.adoc
+++ b/docs/modules/ROOT/pages/guide/import-or-pin.adoc
@@ -40,7 +40,83 @@ In your outputs section:
     });
 ```
 
+[[mkHerculesCI]]
+== Flake without `flake-parts`
+
+This is the recommended integration _if migrating to flake-parts is not an option_. Otherwise follow the steps for https://flake.parts/getting-started.html#existing-flake[migrating an existing flake].
+
+Limitations:
+
+* Deployment modules can't set attributes outside the `herculesCI` flake output attribute.
+* The implementation is more complicated than `mkFlake`, in case something breaks.
+
+Benefits:
+
+* You only have to set a single flake output attribute.
+* Make use of high level features like the `flake-update` and `github-pages`
+   options.
+* Merge effects into the `onPush.default` job, so they run after build success.
+* Run checks that are defined by flake-parts modules.
+
+Add to the flake inputs:
+
+```nix
+hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+```
+
+Call the arguments to the flake outputs function `inputs`; add `inputs@` or if it has already been named, adapt the steps after. Example:
+
+```nix
+outputs = inputs@{ nixpkgs, ... }:
+```
+
+Define the `herculesCI` flake output attribute. Here's a complete example:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+  };
+
+  outputs = inputs@{ nixpkgs, ... }:
+    # This attrset might instead  be `flake-utils.forEachSystem` or similar.
+    {
+      packages = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"] (system: {
+        default = nixpkgs.legacyPackages.${system}.nix.doc;
+      });
+    }
+    // {
+      herculesCI = inputs.hercules-ci-effects.lib.mkHerculesCI { inherit inputs; } {
+        # Values for flake-parts options may be written here, including
+        # non-Hercules-CI options, but those will only take affect in CI and the `hci`
+        # command.
+
+        # Automatic flake updates
+        # hercules-ci.flake-update.enable = true;
+
+        # If your flake already had a `herculesCI` attribute, move it here.
+        herculesCI {
+          # Set this to the systems you want to be checked in CI.
+          ciSystems = [ "x86_64-linux" ... ];
+        };
+
+        # Some modules have options in `perSystem`
+        perSystem = { system, ... } = {
+          # Many flakes call Nixpkgs, to set some `config` or `overlays`.
+          # If yours needs that, it's best to reuse your pkgs here. Example:
+          # _module.args.pkgs = pkgsFor.${system};
+        };
+      };
+    };
+}
+```
+
+Without defining any values in the module (second `mkHerculesCI` argument), the behavior of Hercules CI will be the same, but mediated by the `hercules-ci-effects` flake-parts module.
+
 == Flakes with overlay
+
+This method is not recommended, because it does not support effect definitions via flake options.
 
 Add to the flake inputs:
 
@@ -66,6 +142,8 @@ In your outputs section, call Nixpkgs with the overlay:
 ```
 
 == Flakes without overlay
+
+This method is not recommended, because it does not support effect definitions via flake options.
 
 Although overlays are a convenient way to make definitions available to all
 your expressions, they aren't necessary for `hercules-ci-effects`.

--- a/docs/modules/ROOT/pages/reference/effect-modules/core.adoc
+++ b/docs/modules/ROOT/pages/reference/effect-modules/core.adoc
@@ -5,4 +5,4 @@ The xref:reference/nix-functions/modularEffect.adoc[`modularEffect`] function is
 
 This page documents the options which are always available. You may add additional options using the module `imports` syntax.
 
-include::partial$options.adoc[leveloffset=0]
+include::partial$options.adoc[leveloffset=-1]

--- a/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
+++ b/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
@@ -14,4 +14,6 @@ include::partial$options/git-update.adoc[leveloffset=0]
 
 ## See also
 
+ - xref:reference/nix-functions/gitWriteBranch.adoc[`gitWriteBranch`] to replace branch contents.
+
  - xref:reference/nix-functions/flakeUpdate.adoc[`flakeUpdate`] to update flake input revisions.

--- a/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
+++ b/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
@@ -1,11 +1,13 @@
 # Git-related Modules
 
+[[git-auth]]
 ## `git-auth`
 
 The module provides the basics for working with a git repository.
 
 include::partial$options/git-auth.adoc[leveloffset=0]
 
+[[git-update]]
 ## `git-update`
 
 A module that facilitates the updating of a git repository.

--- a/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
+++ b/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
@@ -1,0 +1,17 @@
+# Git-related Modules
+
+## `git-auth`
+
+The module provides the basics for working with a git repository.
+
+include::partial$options/git-auth.adoc[leveloffset=0]
+
+## `git-update`
+
+A module that facilitates the updating of a git repository.
+
+include::partial$options/git-update.adoc[leveloffset=0]
+
+## See also
+
+ - xref:reference/nix-functions/flakeUpdate.adoc[`flakeUpdate`] to update flake input revisions.

--- a/docs/modules/ROOT/pages/reference/flake-parts/github-pages.adoc
+++ b/docs/modules/ROOT/pages/reference/flake-parts/github-pages.adoc
@@ -1,0 +1,6 @@
+
+# `hercules-ci.github-pages`
+
+These options configure a GitHub Pages deployment to run when the build for the https://flake.parts/options/hercules-ci-effects.html#opt-hercules-ci.github-pages.branch[`hercules-ci.github-pages.branch`] completes.
+
+See also the xref:guide/deploy-to-github-pages.adoc[Guide] and the https://flake.parts/options/hercules-ci-effects.html[other options].

--- a/docs/modules/ROOT/pages/reference/nix-functions/gitWriteBranch.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/gitWriteBranch.adoc
@@ -1,10 +1,12 @@
 
+[[gitWriteBranch]]
 = `gitWriteBranch`
 
 _gitWriteBranch {two-colons} Module -> Effect_
 
 A xref:reference/nix-functions/modularEffect.adoc[`modularEffect`] effect that checks out a repository, replaces a contents and pushes to a branch. Optionally, it can create a pull request.
 
+[[example]]
 == Example
 
 Here's an example of the `herculesCI` attribute for a non-flake-parts project.

--- a/docs/modules/ROOT/pages/reference/nix-functions/gitWriteBranch.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/gitWriteBranch.adoc
@@ -1,0 +1,54 @@
+
+= `gitWriteBranch`
+
+_gitWriteBranch {two-colons} Module -> Effect_
+
+A xref:reference/nix-functions/modularEffect.adoc[`modularEffect`] effect that checks out a repository, replaces a contents and pushes to a branch. Optionally, it can create a pull request.
+
+== Example
+
+Here's an example of the `herculesCI` attribute for a non-flake-parts project.
+
+```nix
+let hci-effects = hercules-ci-effects.lib.withPkgs pkgs;
+in
+# ...
+herculesCI = { branch, primaryRepo, ... }: {
+  # If you're switching from a nix-build style job configuration, you'll need
+  # to define `onPush.default.outputs` to substitute for the old behavior.
+  # It is traversed more eagerly, so large structures may need `dontRecurseIntoAttrs`.
+  # onPush.default.outputs = { inherit mypkg; };
+  onPush.doc-branch = {
+    # Branch for which the effect is triggered
+    enable = branch == "master";
+    outputs = {
+      effects = {
+        update = hci-effects.gitWriteBranch {
+          git.checkout.remote.url = primaryRepo.remoteHttpUrl;
+          git.checkout.forgeType = "github";
+          git.checkout.user = "x-access-token";
+          # Branch to write to
+          git.update.branch = "doc";
+          contents = self.packages.x86_64-linux.doc-branch-contents
+        };
+      };
+    };
+  };
+};
+```
+
+[[effect-options]]
+== Effect Options
+
+include::partial$options/gitWriteBranch.adoc[leveloffset=0]
+
+[[associated-options]]
+== Associated Options
+
+Provided by included modules.
+
+ - xref:reference/effect-modules/git.adoc#opt-git.checkout.remote.url[`git.checkout.remote.url`]
+ - xref:reference/effect-modules/git.adoc#opt-git.checkout.forgeType[`git.checkout.forgeType`]
+ - xref:reference/effect-modules/git.adoc#opt-git.checkout.user[`git.checkout.user`]
+ - xref:reference/effect-modules/git.adoc#opt-git.update.branch[`git.update.branch`]
+ - xref:reference/effect-modules/git.adoc#opt-git.update.pullRequest.enable[`git.update.pullRequest.enable`]

--- a/effects/default.nix
+++ b/effects/default.nix
@@ -32,6 +32,14 @@ in
 
   modularEffect = module: (evalEffectModules { modules = [ module ]; }).config.effectDerivation;
 
+  modularEffectWithUserModule = name: libraryModule: userModule: 
+    self.modularEffect ({ lib, ... }: {
+      imports = [
+        libraryModule
+        (lib.setDefaultModuleLocation "${name} invocation parameters module" userModule)
+      ];
+    });
+
   runIf = condition: v:
     recurseIntoAttrs (
       (
@@ -44,6 +52,8 @@ in
     );
 
   flakeUpdate = callPackage ./flake-update/effect-fun.nix { };
+
+  gitWriteBranch = self.modularEffectWithUserModule "gitWriteBranch" ./write-branch/effect-module.nix;
 
   netlifyDeploy = callPackage ./netlify { };
   netlifySetupHook = pkgs.runCommand "hercules-ci-netlify-setup-hook" {} ''

--- a/effects/default.nix
+++ b/effects/default.nix
@@ -75,6 +75,7 @@ in
   effectVMTest = callPackage ./effect-vm-test { extraModule = { config.hci = pkgs.hci; }; };
 
   effects = self;
+  hci-effects = self;
 
   inherit callPackage;
 }

--- a/effects/effect-vm-test/effects-module.nix
+++ b/effects/effect-vm-test/effects-module.nix
@@ -77,6 +77,7 @@ in
         A collection of secrets available on the mock agent.
       '';
       type = types.lazyAttrsOf (types.lazyAttrsOf types.raw);
+      default = {};
     };
   };
 

--- a/effects/flake-update/test.nix
+++ b/effects/flake-update/test.nix
@@ -1,4 +1,4 @@
-{ effectVMTest, effects, hello, lib, mkEffect, runCommand, writeText }:
+{ effectVMTest, hci-effects, hello, lib, mkEffect, runCommand, writeText }:
 
 let
   
@@ -25,7 +25,7 @@ effectVMTest {
     environment.systemPackages = [ pkgs.jq ];
   };
   effects = {
-    update = effects.flakeUpdate {
+    update = hci-effects.flakeUpdate {
       gitRemote = "http://gitea:3000/test/repo";
       user = "test";
       forgeType = "gitea";

--- a/effects/flake-update/test.nix
+++ b/effects/flake-update/test.nix
@@ -1,29 +1,15 @@
-{ effectVMTest, hci-effects, hello, lib, mkEffect, runCommand, writeText }:
+{ effectVMTest, hci-effects }:
 
 let
-  
+
 in
 effectVMTest {
-  imports = [ ../testsupport/dns.nix ];
+  imports = [
+    ../testsupport/dns.nix
+    ../testsupport/gitea.nix
+    ../testsupport/setup.nix
+  ];
   name = "flake-update";
-  nodes = {
-    gitea = { pkgs, ... }: {
-      services.gitea.enable = true;
-      services.gitea.settings.service.DISABLE_REGISTRATION = true;
-      # services.gitea.settings.log.LEVEL = "Trace";
-      # services.gitea.settings.databas.LOG_SQL = true;
-      services.gitea.settings.log.LEVEL = "Info";
-      services.gitea.settings.database.LOG_SQL = false;
-      networking.firewall.allowedTCPPorts = [ 3000 ];
-      environment.systemPackages = [ pkgs.gitea ];
-    };
-    client = { pkgs, ... }: {
-      environment.systemPackages = [ pkgs.git ];
-    };
-  };
-  defaults = { pkgs, ... }: {
-    environment.systemPackages = [ pkgs.jq ];
-  };
   effects = {
     update = hci-effects.flakeUpdate {
       gitRemote = "http://gitea:3000/test/repo";
@@ -32,27 +18,10 @@ effectVMTest {
       createPullRequest = false; # not supported
     };
   };
-  secrets = {
-  };
-  
-  testScript = ''
-    start_all()
-    gitea.wait_for_unit("gitea.service")
 
-    gitea.succeed("""
-      su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea admin user create \
-        --username test --password test123 --email test@client'
-    """)
+  testCases = ''
 
-    client.wait_for_unit("multi-user.target")
-    gitea.wait_for_open_port(3000)
-
-    token = gitea.succeed("""
-      curl --fail -X POST http://test:test123@gitea:3000/api/v1/users/test/tokens \
-        -H 'Accept: application/json' -H 'Content-Type: application/json' \
-        -d '{\"name\":\"token\"}' \
-        | jq -r '.sha1'
-    """).strip()
+    token = gitea_admin_token
 
     repo = client.succeed("""
       curl -v --fail -X POST http://gitea:3000/api/v1/user/repos \
@@ -72,12 +41,6 @@ effectVMTest {
 
     dep_commits = client.succeed("""
     (
-    # set -x
-    echo "http://test:test123@gitea:3000" >~/.git-credentials
-    git config --global credential.helper store
-    git config --global user.email "test@client"
-    git config --global user.name "Test User"
-
     git clone http://gitea:3000/test/dep.git
     cd dep
     touch file
@@ -123,7 +86,7 @@ effectVMTest {
 
     assert len(dep_commits) == 2
 
-    agent.succeed("echo test123 | effect-update")
+    agent.succeed(f"echo {gitea_admin_password} | effect-update")
 
     repo_update_rev = client.succeed(f"""
       (
@@ -145,7 +108,7 @@ effectVMTest {
     """).rstrip()
 
     with subtest("Idempotent and successful when up to date"):
-      agent.succeed("echo test123 | effect-update")
+      agent.succeed(f"echo {gitea_admin_password} | effect-update")
       client.succeed(f"""
         (
           set -x

--- a/effects/modules/git-update.nix
+++ b/effects/modules/git-update.nix
@@ -2,6 +2,7 @@
 let
   inherit (lib)
     mkOption
+    optionalAttrs
     optionals
     optionalString
     types
@@ -79,6 +80,8 @@ in
     env = {
       HCI_GIT_REMOTE_URL = config.git.checkout.remote.url;
       HCI_GIT_UPDATE_BRANCH = cfg.branch;
+    }
+    // optionalAttrs cfg.pullRequest.enable {
       HCI_GIT_UPDATE_PR_TITLE = cfg.pullRequest.title;
       HCI_GIT_UPDATE_PR_BODY = cfg.pullRequest.body;
     };

--- a/effects/testsupport/gitea.nix
+++ b/effects/testsupport/gitea.nix
@@ -1,0 +1,57 @@
+{ lib, ... }: {
+  imports = [
+    ../testsupport/dns.nix
+    ../testsupport/setup.nix
+  ];
+  nodes = {
+    gitea = { pkgs, ... }: {
+      services.gitea.enable = true;
+      services.gitea.settings.service.DISABLE_REGISTRATION = true;
+      # services.gitea.settings.log.LEVEL = "Trace";
+      # services.gitea.settings.databas.LOG_SQL = true;
+      services.gitea.settings.log.LEVEL = "Info";
+      services.gitea.settings.database.LOG_SQL = false;
+      networking.firewall.allowedTCPPorts = [ 3000 ];
+      environment.systemPackages = [ pkgs.gitea ];
+    };
+    client = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.git ];
+    };
+  };
+  defaults = { pkgs, ... }: {
+    environment.systemPackages = [ pkgs.jq ];
+  };
+
+  setupScript = ''
+    import shlex
+
+    gitea.wait_for_unit("gitea.service")
+
+    gitea_admin = "test"
+    gitea_admin_password = "test123test"
+
+    gitea.succeed(f"""
+      su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea admin user create \
+        --username {gitea_admin} --password {gitea_admin_password} --email test@client'
+    """)
+
+    client.wait_for_unit("multi-user.target")
+    gitea.wait_for_open_port(3000)
+
+    gitea_admin_token = gitea.succeed(f"""
+      curl --fail -X POST http://{gitea_admin}:{gitea_admin_password}@gitea:3000/api/v1/users/test/tokens \
+        -H 'Accept: application/json' -H 'Content-Type: application/json' \
+        -d {shlex.quote( '{"name":"token"}' )} \
+        | jq -r '.sha1'
+    """).strip()
+
+    client.succeed(f"""
+      echo "http://{gitea_admin}:{gitea_admin_password}@gitea:3000" >~/.git-credentials-admin
+      git config --global credential.helper 'store --file ~/.git-credentials-admin'
+      git config --global user.email "test@client"
+      git config --global user.name "Test User"
+      git config --global gc.autodetach 0
+      git config --global gc.auto 0
+    """)
+  '';
+}

--- a/effects/testsupport/setup.nix
+++ b/effects/testsupport/setup.nix
@@ -1,0 +1,42 @@
+{ lib, config, ... }:
+let
+  inherit (lib)
+    concatStrings
+    mapAttrsToList
+    mkOption
+    types
+    ;
+in
+{
+
+  options = {
+    setupScript = mkOption {
+      type = types.lines;
+      description = ''
+        Python code that runs before the main test.
+
+        Variables defined by this code will be available in the test.
+      '';
+      default = "";
+    };
+    testCases = mkOption {
+      type = types.str;
+      description = ''
+        The test cases. See `testScript`.
+      '';
+    };
+  };
+
+  config = {
+    testScript = ''
+      start_all();
+
+      ${config.setupScript}
+
+      ### SETUP COMPLETE ###
+
+      ${config.testCases}
+    '';
+  };
+
+}

--- a/effects/write-branch/effect-module.nix
+++ b/effects/write-branch/effect-module.nix
@@ -1,0 +1,96 @@
+{ lib, config, ... }:
+let
+  inherit (lib)
+    mkAfter
+    mkDefault
+    mkOption
+    types
+    ;
+
+  isStoreContents = lib.hasPrefix builtins.storeDir config.contents;
+in
+{
+  imports = [
+    ../modules/git-update.nix
+  ];
+
+  options = {
+    contents = mkOption {
+      type = types.path;
+      description = ''
+        The contents to which the branch will be set.
+
+        The basename of `contents` will not be used.
+      '';
+    };
+    destination = mkOption {
+      type = types.str;
+      description = ''
+        Relative path into repository that will be replaced by the `contents`.
+
+        Any pre-existing contents at this location will be removed.
+      '';
+      default = ".";
+    };
+    message = mkOption {
+      type = types.str;
+      description = ''
+        Commit message for the updated contents.
+      '';
+      defaultText = lib.literalMD ''
+        "Update " + the `destination` or `git.update.branch`
+      '';
+      default = "Update ${if config.destination == "." then config.git.update.branch else config.destination}"
+        + lib.optionalString isStoreContents
+          "\n\nStore path: ${config.contents}";
+    };
+    allowExecutableFiles = mkOption {
+      type = types.bool;
+      description = ''
+        Whether executable files are allowed. If not, these permission bits will
+        be omitted when copying the `contents`.
+      '';
+      default = true;
+    };
+  };
+
+  config = {
+    secretsMap.token = mkDefault { type = "GitToken"; };
+
+    name = "write-branch";
+
+    env.contents = "${config.contents}";
+    env.message = "${config.message}";
+    env.destination =
+      lib.throwIf (lib.hasPrefix "/" config.destination)
+        "gitWriteBranch: destination must be a relative path, but got ${config.destination}"
+        config.destination;
+
+    git.update.script = mkAfter ''
+      echo 1>&2 'Writing new tree...'
+
+      if test -e "$destination"; then
+        git rm -rf "$destination"
+      else
+        mkdir -p "$(dirname "$destination")"
+      fi
+
+      if test -d "''${contents}"; then
+        contents="''${contents}/."
+      fi
+      cp -r ${lib.optionalString (!config.allowExecutableFiles) " --no-preserve=mode"} \
+        "''${contents}" \
+        "$destination"
+
+      git add -v "$destination"
+
+      if git diff --cached --quiet; then
+        echo Nothing to commit.
+      else
+        git commit -m "''${message}"
+      fi
+    '';
+
+    git.update.pullRequest.enable = mkDefault false;
+  };
+}

--- a/effects/write-branch/test.nix
+++ b/effects/write-branch/test.nix
@@ -1,0 +1,161 @@
+{ effectVMTest, hci-effects, runCommand }:
+
+let
+  contents = runCommand "contents" { } ''
+    mkdir -p $out/bin
+    echo hi >$out/index.md
+    echo hidden >$out/.i-am-hidden
+    echo 'echo hello' >$out/bin/hello
+    chmod a+x $out/bin/hello
+    ln -s hello $out/bin/greet
+  '';
+  lessContents = runCommand "contents" { } ''
+    mkdir -p $out
+    echo hi >$out/index.md
+  '';
+  defaults = { lib, ... }: {
+    _file = "${__curPos.file}:let defaults";
+    git.checkout.remote.url = "http://gitea:3000/test/repo";
+    git.checkout.forgeType = "gitea";
+    git.checkout.user = "test";
+    git.update.branch = "my-test-branch";
+    contents = lib.mkDefault contents;
+  };
+in
+effectVMTest {
+  imports = [
+    ../testsupport/dns.nix
+    ../testsupport/gitea.nix
+    ../testsupport/setup.nix
+  ];
+  name = "flake-update";
+  effects = {
+    write-contents = hci-effects.gitWriteBranch {
+      imports = [ defaults ];
+    };
+    write-contents-no-exe = hci-effects.gitWriteBranch {
+      imports = [ defaults ];
+      allowExecutableFiles = false;
+    };
+    write-contents-less = hci-effects.gitWriteBranch {
+      imports = [ defaults ];
+      contents = lessContents;
+    };
+    write-contents-destination = hci-effects.gitWriteBranch {
+      imports = [ defaults ];
+      destination = "www/public";
+    };
+  };
+
+  testCases = ''
+
+    token = gitea_admin_token
+
+    repo = client.succeed("""
+      curl -v --fail -X POST http://gitea:3000/api/v1/user/repos \
+        -H 'Accept: application/json' -H 'Content-Type: application/json' \
+        """ + f"-H 'Authorization: token {token}'" + """ \
+        -d '{"name":"repo", "private":true}'
+    """)
+    print(repo)
+
+    client.succeed("""
+      git clone http://gitea:3000/test/repo.git
+      cd repo
+      mkdir -p redundant-dir
+      touch redundant-file redundant-dir/keep
+      git add .
+      git commit -m 'init'
+      git push
+    """).splitlines()
+
+    with subtest("Can write contents"):
+      agent.succeed(f"echo {gitea_admin_password} | effect-write-contents")
+
+      repo_update_rev = client.succeed("""
+        (
+          set -x
+          cd repo
+          git fetch origin
+          git checkout my-test-branch
+          find .
+          test -x bin/hello
+          test -L bin/greet
+          echo hi | cmp - index.md
+          echo hidden | cmp - .i-am-hidden
+          ! test -e redundant-file
+          ! test -e redundant-dir
+          git log | grep -F 'Update my-test-branch'
+          git log | grep -F 'Store path: ${contents}'
+        )
+      """).rstrip()
+
+    with subtest("Idempotent and successful when up to date"):
+      agent.succeed(f"echo {gitea_admin_password} | effect-write-contents")
+      client.succeed("""
+        (
+          set -x
+          cd repo
+          git pull
+
+          lines=$(git show | grep -F 'Update my-test-branch' | wc -l)
+          [[ 1 == $lines ]]
+
+          lines=$(git log | grep -F 'Update my-test-branch' | wc -l)
+          [[ 1 == $lines ]]
+        )
+    """)
+
+    with subtest("Removes executable bit when that is not allowed"):
+      agent.succeed(f"echo {gitea_admin_password} | effect-write-contents-no-exe")
+      client.succeed("""
+        (
+          set -x
+          cd repo
+          git pull
+          test -r bin/hello
+          ! test -x bin/hello
+
+          lines=$(git log | grep -F 'Update my-test-branch' | wc -l)
+          [[ 2 == $lines ]]
+        )
+      """)
+
+    with subtest("Removes files and directories that are not in the contents anymore"):
+      agent.succeed(f"echo {gitea_admin_password} | effect-write-contents-less")
+      client.succeed("""
+        (
+          set -x
+          cd repo
+          git pull
+          test index.md
+          ! test -e bin
+          ! test -e .i-am-hidden
+
+          lines=$(git log | grep -F 'Update my-test-branch' | wc -l)
+          [[ 3 == $lines ]]
+        )
+      """)
+
+    with subtest("Files and directories can be put in a directory without replacing everything"):
+      agent.succeed(f"echo {gitea_admin_password} | effect-write-contents-destination")
+      client.succeed("""
+        (
+          set -x
+          cd repo
+          git pull
+          test index.md
+          ! test -e bin
+          ! test -e .i-am-hidden
+          test -r www/public/index.md
+          test -r www/public/.i-am-hidden
+          test -x www/public/bin/hello
+          test -L www/public/bin/greet
+
+          lines=$(git log | grep -F 'Update www/public' | wc -l)
+          [[ 1 == $lines ]]
+        )
+      """)
+
+  '';
+}

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -55,6 +55,7 @@ top@{ withSystem, lib, inputs, config, ... }: {
   perSystem = { pkgs, hci-effects, inputs', ... }: {
     checks = {
       flake-update = hci-effects.callPackage ./effects/flake-update/test.nix { };
+      write-branch = hci-effects.callPackage ./effects/write-branch/test.nix { };
       ssh = hci-effects.callPackage ./effects/ssh/test.nix { };
     };
     devShells.default = pkgs.mkShell {

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -14,6 +14,10 @@ top@{ withSystem, lib, inputs, config, ... }: {
       evaluation-herculesCI =
         let it = (import ./flake-modules/herculesCI-eval-test.nix { inherit inputs; });
         in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };
+
+      evaluation-mkHerculesCI =
+        let it = (import ./lib/mkHerculesCI-test.nix { inherit inputs; });
+        in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };
     };
 
     tests = withSystem "x86_64-linux" ({ hci-effects, pkgs, ... }: {

--- a/flake-docs-render.nix
+++ b/flake-docs-render.nix
@@ -1,6 +1,33 @@
 {
-  perSystem = { config, pkgs, lib, ... }: {
-    packages.generated-option-doc-modularEffect =
+  perSystem = { config, pkgs, lib, ... }:
+  let
+    inherit (lib)
+      concatMap
+      hasPrefix
+      removePrefix
+      ;
+
+    filterTransformOptions = { sourceName, sourcePath, baseUrl }:
+      let sourcePathStr = toString sourcePath;
+      in
+      opt:
+      let
+        declarations = concatMap
+          (decl:
+            if hasPrefix sourcePathStr (toString decl)
+            then
+              let subpath = removePrefix sourcePathStr (toString decl);
+              in [{ url = baseUrl + subpath; name = sourceName + subpath; }]
+            else [ ]
+          )
+          opt.declarations;
+      in
+      if declarations == [ ]
+      then opt // { visible = false; }
+      else opt // { inherit declarations; };
+
+  
+    renderModule = { sourceName, sourcePath, modules }:
       # TODO: use the render pipeline in flake-parts,
       #       which has support for things like {options}`foo`.
       let
@@ -12,28 +39,78 @@
                 # type = lib.types.submodule;
               };
             }
-            ./effects/effect/effect-module.nix
-          ];
+            ./effects/effect/effect-module.nix 
+          ] ++ modules;
         };
+        baseUrl = 
+          "https://github.com/hercules-ci/hercules-ci-effects/blob/master" 
+            + lib.strings.removePrefix (toString ./.) (toString sourcePath);
+
       in
       (pkgs.nixosOptionsDoc
         {
           options = eval.options;
-        }).optionsCommonMark;
+          transformOptions = filterTransformOptions {
+            inherit sourceName baseUrl sourcePath;
+          };
+          documentType = "none";
+          warningsAreErrors = true;
+          markdownByDefault = true;
+        }).optionsDocBook;
+  in
+  {
+    packages.generated-option-doc-modularEffect =
+      renderModule {
+        sourceName = "effect";
+        sourcePath = ./effects/effect;
+        modules = [ ];
+      };
+
+    packages.generated-option-doc-git-auth =
+      renderModule {
+        sourceName = "git-auth";
+        sourcePath = ./effects/modules/git-auth.nix;
+        modules = [ ./effects/modules/git-auth.nix ];
+      };
+
+    packages.generated-option-doc-git-update =
+      renderModule {
+        sourceName = "git-auth";
+        sourcePath = ./effects/modules/git-update.nix;
+        modules = [ ./effects/modules/git-update.nix ];
+      };
+
 
     packages.generated-antora-files =
       pkgs.runCommand "generated-antora-files"
         {
-          nativeBuildInputs = [ pkgs.pandoc ];
+          nativeBuildInputs = [ pkgs.pandoc pkgs.libxslt.bin ];
           modularEffect = config.packages.generated-option-doc-modularEffect;
+          git_auth = config.packages.generated-option-doc-git-auth;
+          git_update = config.packages.generated-option-doc-git-update;
         }
-        # TODO: use the render pipeline in flake-parts,
-        #       which has support for things like {options}`foo`.
         ''
-          mkdir -p $out/modules/ROOT/partials
-          pandoc --from=markdown --to=asciidoc \
+          mkdir -p $out/modules/ROOT/partials/options
+
+          function convert() {
+            xsltproc --stringparam title Options \
+              -o options.db.xml ${./options.xsl} \
+              -
+            pandoc --from=docbook --to=asciidoc \
+              < options.db.xml\
+            | sed -e 's/^ *//'  -e 's/^== *$//'
+          }
+          convert \
             < $modularEffect \
-            > $out/modules/ROOT/partials/options.adoc
+            >$out/modules/ROOT/partials/options.adoc \
+
+          convert \
+            < $git_auth \
+            > $out/modules/ROOT/partials/options/git-auth.adoc
+
+           convert\
+            < $git_update \
+            > $out/modules/ROOT/partials/options/git-update.adoc
         '';
   };
 }

--- a/flake-docs-render.nix
+++ b/flake-docs-render.nix
@@ -66,6 +66,13 @@
         modules = [ ];
       };
 
+    packages.generated-option-doc-gitWriteBranch =
+      renderModule {
+        sourceName = "write-branch";
+        sourcePath = ./effects/write-branch;
+        modules = [ ./effects/write-branch/effect-module.nix ];
+      };
+
     packages.generated-option-doc-git-auth =
       renderModule {
         sourceName = "git-auth";
@@ -86,6 +93,7 @@
         {
           nativeBuildInputs = [ pkgs.pandoc pkgs.libxslt.bin ];
           modularEffect = config.packages.generated-option-doc-modularEffect;
+          gitWriteBranch = config.packages.generated-option-doc-gitWriteBranch;
           git_auth = config.packages.generated-option-doc-git-auth;
           git_update = config.packages.generated-option-doc-git-update;
         }
@@ -103,6 +111,10 @@
           convert \
             < $modularEffect \
             >$out/modules/ROOT/partials/options.adoc \
+
+          convert \
+            < $gitWriteBranch \
+            > $out/modules/ROOT/partials/options/gitWriteBranch.adoc
 
           convert \
             < $git_auth \

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -3,6 +3,7 @@
     ./flake-modules/module-argument.nix
     ./flake-modules/herculesCI-attribute.nix
     ./flake-modules/herculesCI-helpers.nix
+    ./flake-modules/github-pages.nix
     ./effects/flake-update/flake-module.nix
   ];
 }

--- a/flake-modules/github-pages.nix
+++ b/flake-modules/github-pages.nix
@@ -1,0 +1,135 @@
+top@{ config, options, lib, inputs, withSystem, getSystem, flake-parts-lib, ... }:
+let
+  inherit (lib)
+    mkIf
+    mkMerge
+    mkOption
+    types
+    ;
+
+  inherit (config) defaultEffectSystem;
+  inherit (flake-parts-lib) mkPerSystemOption;
+
+  cfg = config.hercules-ci.github-pages;
+
+  enable = cfg.branch != null;
+
+  githubPagesSettings = {
+    _file = "${__curPos.file}:let githubPagesSettings";
+    git.checkout.forgeType = "github";
+    git.checkout.user = "x-access-token";
+    git.update.branch = "gh-pages";
+  };
+
+in
+{
+  options = {
+    perSystem = mkPerSystemOption ({ config, ... }: {
+      options = {
+        hercules-ci.github-pages.settings = lib.mkOption {
+          type = types.deferredModule;
+          description = ''
+            Modular settings for the GitHub Pages effect.
+
+            See [`gitWriteBranch`](https://docs.hercules-ci.com/hercules-ci-effects/reference/nix-functions/gitWriteBranch.html#effect_options) for options.
+          '';
+          example = lib.literalExpression ''
+            {
+              contents = config.packages.docs + "/share/doc/mypkg/html";
+            }
+          '';
+        };
+      };
+    });
+
+    hercules-ci.github-pages = {
+      branch = lib.mkOption {
+        type = types.nullOr types.str;
+        description = ''
+          A GitHub Pages deployment will be triggered when changes are pushed to this branch.
+
+          A non-null value enables the effect.
+        '';
+        default = null;
+      };
+      check.enable = lib.mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to make sure that the effect is buildable. This adds
+          `checks.''${config.defaultEffectSystem}.gh-pages` to `onPush.default`.
+        '';
+      };
+      pushJob = lib.mkOption {
+        type = types.str;
+        description = ''
+          The Hercules CI job in which to perform the deployment.
+          
+          By default the GitHub pages deployment is triggered by the `onPush.default` job,
+          so that the deployment only proceeds when the default builds are successful.
+        '';
+        default = "default";
+      };
+      settings = lib.mkOption {
+        type = types.deferredModule;
+        description = ''
+          Modular settings for the GitHub Pages effect.
+
+          For system-dependent settings, define [`perSystem.hercules-ci.github-pages.settings`](#opt-perSystem.hercules-ci.github-pages.settings) instead.
+
+          See [`gitWriteBranch`](https://docs.hercules-ci.com/hercules-ci-effects/reference/nix-functions/gitWriteBranch.html#effect_options) for options.
+        '';
+        example = lib.literalExpression ''
+          {
+            message = "Update GitHub Pages";
+          }
+        '';
+      };
+    };
+  };
+
+  config = mkIf enable {
+    perSystem = { hci-effects, system, ... }:
+      let
+        deploy =
+          hci-effects.gitWriteBranch {
+            imports = [
+              githubPagesSettings
+              cfg.settings
+            ];
+            git.checkout.remote.url = "https://fake-repo-for.checks.github-pages-effect-is-buildable";
+          };
+      in
+      {
+        checks = lib.optionalAttrs (system == defaultEffectSystem) {
+          github-pages-effect-is-buildable = deploy.inputDerivation;
+        };
+      };
+
+    hercules-ci.github-pages.settings = (getSystem defaultEffectSystem).hercules-ci.github-pages.settings;
+
+    herculesCI = herculesCI@{ config, ... }:
+      let
+        deploy = withSystem defaultEffectSystem ({ config, hci-effects, ... }:
+          hci-effects.gitWriteBranch {
+            imports = [
+              githubPagesSettings
+              cfg.settings
+            ];
+            git.checkout.remote.url = herculesCI.config.repo.remoteHttpUrl;
+          }
+        );
+      in
+      {
+        onPush = mkMerge [
+          # deploy
+          {
+            ${cfg.pushJob}.outputs.effects.gh-pages =
+              lib.optionalAttrs
+                (herculesCI.config.repo.branch == cfg.branch)
+                deploy;
+          }
+        ];
+      };
+  };
+}

--- a/flake-modules/herculesCI-attribute.nix
+++ b/flake-modules/herculesCI-attribute.nix
@@ -192,11 +192,23 @@ let
           Flake systems for which to generate attributes in `herculesCI.onPush.default.outputs`.
         '';
       };
+      flakeForOnPushDefault = mkOption {
+        type = types.raw;
+        default = self;
+        defaultText = lib.literalExpression "self";
+        description = ''
+          The flake to use when automatically deriving the onPush.default job.
+
+          If you use mkFlake (you should), you have no reason to set this.
+          This is primarily an extension point for `mkHerculesCI`.
+        '';
+        internal = true;
+      };
     };
     config = {
       onPush.default.outputs =
         default-hci-for-flake.flakeToOutputs
-          self
+          { outputs = config.flakeForOnPushDefault; }
           { ciSystems = lib.genAttrs config.ciSystems (system: {}); };
       out = {
         inherit (config) onPush onSchedule ciSystems;

--- a/flake-modules/herculesCI-attribute.nix
+++ b/flake-modules/herculesCI-attribute.nix
@@ -208,7 +208,7 @@ let
     config = {
       onPush.default.outputs =
         default-hci-for-flake.flakeToOutputs
-          { outputs = config.flakeForOnPushDefault; }
+          config.flakeForOnPushDefault
           { ciSystems = lib.genAttrs config.ciSystems (system: {}); };
       out = {
         inherit (config) onPush onSchedule ciSystems;

--- a/flake-modules/herculesCI-attribute.nix
+++ b/flake-modules/herculesCI-attribute.nix
@@ -224,7 +224,7 @@ in
       # These are lazy errors in order to allow some exploration in nix repl.
       # hci repl: https://github.com/hercules-ci/hercules-ci-agent/issues/459
       herculesCI ? throw "`<flake>.outputs.herculesCI` requires an `herculesCI` argument.",
-      primaryRepo ? throw "`<flake>.outputs.primaryRepo` requires a `primaryRepo` argument.",
+      primaryRepo ? throw "`<flake>.outputs.herculesCI` requires a `primaryRepo` argument.",
       ... }:
       let
         paramModule = {

--- a/flake-public-outputs.nix
+++ b/flake-public-outputs.nix
@@ -12,6 +12,8 @@
       let effects = import ./effects/default.nix effects pkgs;
       in effects;
 
+    lib.mkHerculesCI = import ./lib/mkHerculesCI.nix inputs;
+
     overlay = final: prev: {
       effects = import ./effects/default.nix final.effects final;
     };

--- a/lib/mkHerculesCI-test.nix
+++ b/lib/mkHerculesCI-test.nix
@@ -1,0 +1,87 @@
+args@
+{ inputs ? hercules-ci-effects.inputs
+, hercules-ci-effects ? if args?inputs then inputs.self else builtins.getFlake "git+file://${toString ./..}"
+}:
+rec {
+  inherit (inputs) flake-parts;
+  inherit (inputs.nixpkgs.lib) attrNames;
+
+  # Approximates https://github.com/NixOS/nix/blob/7cd08ae379746749506f2e33c3baeb49b58299b8/src/libexpr/flake/call-flake.nix#L46
+  # s/flake.outputs/args.outputs/
+  callFlake = args@{ inputs, outputs, sourceInfo }:
+    let
+      outputs = args.outputs (inputs // { self = result; });
+      result = outputs // sourceInfo // { inherit inputs outputs sourceInfo; _type = "flake"; };
+    in
+    result;
+
+  callFlakeOutputs = outputs: callFlake {
+    inherit outputs;
+    inputs = inputs // {
+      inherit hercules-ci-effects;
+    };
+    sourceInfo = { };
+  };
+
+  fakePkg = name: {
+    inherit name;
+    type = "derivation";
+  };
+
+  fakeRepo = {
+    branch = "main";
+    ref = "refs/heads/main";
+    rev = "deadbeef";
+    shortRev = "deadbe";
+    tag = null;
+    remoteHttpUrl = "https://git.forge/repo.git";
+  };
+
+  fakeHerculesCI = { primaryRepo = fakeRepo; inherit (fakeRepo) branch ref; };
+
+  outputs1 = inputs@{ nixpkgs, ... }: {
+    packages = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-darwin" ] (system: {
+      default = nixpkgs.legacyPackages.${system}.nix.doc;
+    });
+
+    herculesCI = inputs.hercules-ci-effects.lib.mkHerculesCI { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      hercules-ci.github-pages.branch = "main";
+      perSystem = { config, self', inputs', system, ... }: {
+        hercules-ci.github-pages.settings.contents = self'.packages.default + "/share/doc/nix/manual";
+      };
+    };
+  };
+  flake1 = callFlakeOutputs outputs1;
+  ci1 = (flake1.herculesCI fakeHerculesCI).onPush.default.outputs;
+
+  outputs1Expected = inputs@{ flake-parts, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
+    imports = [
+      inputs.hercules-ci-effects.flakeModule
+    ];
+    systems = [ "x86_64-linux" "aarch64-darwin" ];
+
+    hercules-ci.github-pages.branch = "main";
+
+    perSystem = { config, self', inputs', pkgs, system, ... }: {
+      packages.default = pkgs.nix.doc;
+      hercules-ci.github-pages.settings.contents = config.packages.default + "/share/doc/nix/manual";
+    };
+  };
+  flake1Expected = callFlakeOutputs outputs1Expected;
+  ci1Expected = (flake1Expected.herculesCI fakeHerculesCI).onPush.default.outputs;
+
+  tests = ok:
+
+    assert attrNames ci1.checks == attrNames ci1Expected.checks;
+
+    assert attrNames ci1.effects == attrNames ci1Expected.effects;
+
+    assert ci1.effects.gh-pages.drvPath == ci1Expected.effects.gh-pages.drvPath;
+
+    assert ci1.checks.x86_64-linux.github-pages-effect-is-buildable.drvPath ==
+      ci1Expected.checks.x86_64-linux.github-pages-effect-is-buildable.drvPath;
+
+    ok;
+
+}

--- a/lib/mkHerculesCI.nix
+++ b/lib/mkHerculesCI.nix
@@ -27,7 +27,7 @@ let
       config = {
         systems = lib.mkDefault [ config.defaultEffectSystem ];
         # We're doing things the other way around...
-        herculesCI.flakeForOnPushDefault = config.flake;
+        herculesCI.flakeForOnPushDefault = { outputs = config.flake; };
 
         # self.herculesCI is supposed to be defined by mkHerculesCI.
         # If we were to set it here, that would cause it to

--- a/lib/mkHerculesCI.nix
+++ b/lib/mkHerculesCI.nix
@@ -1,0 +1,42 @@
+# Static arguments provided by flake-public-outputs.nix
+hercules-ci-effects-inputs@{ flake-parts, ... }:
+
+# User arguments
+{ inputs }: module:
+let
+  flake =
+    flake-parts.lib.mkFlake { inherit inputs; } ({ lib, config, self, ... }: {
+      options = {
+        selfAttributesDefinedViaMkHerculesCI = lib.mkOption {
+          description = ''
+            Flake output attributes that the `mkHerculesCI` caller
+            assigns to the flake outputs, a.k.a. `self`.
+                        
+            These must be excluded from the `self` values that are
+            assigned to the `flake` option and subsequent use in
+            the `onPush.default` job.
+
+            Usually, the default will suffice.
+          '';
+        };
+      };
+      imports = [
+        hercules-ci-effects-inputs.self.flakeModule
+        (lib.setDefaultModuleLocation "the mkHerculesCI argument" module)
+      ];
+      config = {
+        systems = lib.mkDefault [ config.defaultEffectSystem ];
+        # We're doing things the other way around...
+        herculesCI.flakeForOnPushDefault = config.flake;
+
+        # self.herculesCI is supposed to be defined by mkHerculesCI.
+        # If we were to set it here, that would cause it to
+        # recursively merge itself with itself, infinitely.
+        selfAttributesDefinedViaMkHerculesCI = [ "herculesCI" ];
+
+        flake =
+          builtins.removeAttrs (self.outputs or self) config.selfAttributesDefinedViaMkHerculesCI;
+      };
+    });
+in
+flake.herculesCI

--- a/options.xsl
+++ b/options.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+  version="1.0"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:db="http://docbook.org/ns/docbook"
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  >
+  <xsl:template match="/">
+    <xsl:apply-templates/>
+  </xsl:template>
+  <xsl:template match="db:variablelist">
+    <simplesect>
+      <xsl:apply-templates />
+    </simplesect>
+  </xsl:template>
+  <xsl:template match="db:varlistentry">
+    <section xml:id="{db:term/@xml:id}">
+      <title>
+        <xsl:copy-of select="db:term/db:option"/>
+      </title>
+      <xsl:apply-templates select="db:listitem/*"/>
+    </section>
+  </xsl:template>
+  <!-- Pandoc doesn't like block-level simplelist -->
+  <!-- https://github.com/jgm/pandoc/issues/8086 -->
+  <xsl:template match="db:simplelist">
+    <para>
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+    </para>
+  </xsl:template>
+  <!-- Turn filename tags with href attrs into explicit links -->
+  <xsl:template match="db:filename">
+    <link xlink:href="{@xlink:href}">
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+    </link>
+  </xsl:template>
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->

Support more git operations.

 - Reusable git setup code in the form of documented modules
 - `gitWriteBranch` effect
 - GitHub pages module for flake-parts

TODO:
 - [x] what's up with `outputs` now in the `onPush.default` job?
 - [ ] how to push to a repo that isn't the local one?

### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
    - [x] `gitWriteBranch` effect
    - [x] GitHub pages module for flake-parts - eval tests
 - [x] Is the corresponding module up to date?
