### PR TITLE
nix-darwin: Allow `darwinSystem` result or `config` to be passed.

### DIFF
--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixDarwin.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixDarwin.adoc
@@ -7,11 +7,48 @@ Deploys a nix-darwin configuration, to maintain a macOS machine.
 
 Use the nix-darwin installer first, then base the configuration off the generated ~/.nixpkgs/darwin-configuration.nix.
 
+== Examples:
+
+In a flake, or other code that calls `darwin.lib.darwinSystem`,
+
+```nix
+hci-effects.runNixDarwin {
+  ssh.destination = "jane.local";
+  config = self.darwinConfigurations."Janes-MacBook";
+}
+```
+
+or without explicitly using the nix-darwin library,
+
+```nix
+hci-effects.runNixDarwin {
+  ssh.destination = "jane.local";
+
+  configuration = ./configuration.nix;
+  system = "x86_64-darwin";
+  nix-darwin = sources.nix-darwin;
+  nixpkgs = sources.nixpkgs;
+}
+```
+
 [[parameters]]
 == Parameters
 
+[[param-config]]
+=== `config`
+
+An evaluated configuration to deploy, such as returned by `darwin.lib.darwinSystem`.
+
+Unlike a module, such as can be passed to <<param-configuration>>, a configuration contains all required option values, so that other parameters such as <<param-configuration>>, <<param-nix-darwin>>, <<param-nixpkgs>> and <<param-system>> can be omitted.
+
+If needed, it is sufficient to only pass the `config` attribute returned by `darwin.lib.darwinSystem`.
+
+This parameter is optional and mutually exclusive with <<param-configuration>> and aforementioned other parameters.
+
 [[param-configuration]]
 === `configuration`
+
+Optional, mutually exclusive with <<param-config>>.
 
 The main configuration module; file path or module expression.
 
@@ -22,11 +59,15 @@ repo.
 [[param-nix-darwin]]
 === `nix-darwin`
 
+Optional, mutually exclusive with <<param-config>>.
+
 Path of the nix-darwin sources to use.
 
 
 [[param-nixpkgs]]
 === `nixpkgs`
+
+Optional, mutually exclusive with <<param-config>>.
 
 Path of the Nixpkgs sources to use.
 
@@ -56,6 +97,8 @@ See the named arguments in xref:reference/nix-functions/ssh.adoc[]. Example:
 
 [[param-system]]
 === `system`
+
+Optional, mutually exclusive with <<param-config>>.
 
 The Nix `system` of the machine to deploy.
 

--- a/effects/nix-darwin/eval-test.nix
+++ b/effects/nix-darwin/eval-test.nix
@@ -1,0 +1,63 @@
+args@
+{ inputs ? hercules-ci-effects.inputs
+, hercules-ci-effects ? if args?inputs then inputs.self else builtins.getFlake "git+file://${toString ../..}"
+}:
+let
+  testSupport = import ../../lib/testSupport.nix args;
+
+  # TODO: use a flake.lock, so that we can CI the upstream
+  #       also lib.darwinSystem would need follows to inject our own nixpkgs,
+  #       so we use the one from the nix-darwin flake for testing here. Awkward.
+  darwin = builtins.getFlake "github:LnL7/nix-darwin?rev=87b9d090ad39b25b2400029c64825fc2a8868943";
+in
+rec {
+  inherit (inputs) flake-parts;
+  inherit (testSupport) callFlakeOutputs;
+
+  testEqDrv = drv1: drv2:
+    if drv1 == drv2 then true
+    else builtins.trace "Oh-oh, these are different! Check the differences with\nnix-diff ${drv1} ${drv2}" false;
+
+  flake1 = callFlakeOutputs (inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, self, ... }: {
+      imports = [
+        ../../flake-module.nix
+      ];
+      systems = [ "x86_64-linux" ];
+      flake = {
+        darwinConfigurations."Johns-MacBook" = darwin.lib.darwinSystem {
+          system = "x86_64-darwin";
+          modules = [ ./test/configuration.nix ];
+        };
+        test.by-config = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixDarwin {
+            ssh.destination = "john.local";
+            config = self.darwinConfigurations."Johns-MacBook";
+          }
+        );
+        test.by-other-args = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixDarwin {
+            ssh.destination = "john.local";
+            system = "x86_64-darwin";
+            nix-darwin = darwin.outPath;
+            nixpkgs = darwin.inputs.nixpkgs.outPath;
+            configuration = ./test/configuration.nix;
+          }
+        );
+      };
+    })
+  );
+
+  tests = ok:
+
+    # Assumption
+    assert flake1.darwinConfigurations."Johns-MacBook".system
+      == flake1.darwinConfigurations."Johns-MacBook".config.system.build.toplevel;
+
+    assert 
+      testEqDrv flake1.test.by-config.drvPath flake1.test.by-other-args.drvPath;
+
+    ok;
+
+}
+

--- a/effects/nix-darwin/run-nix-darwin.nix
+++ b/effects/nix-darwin/run-nix-darwin.nix
@@ -1,64 +1,83 @@
-{ effects, mkEffect, openssh, path }:
+{ effects, mkEffect, lib, openssh, path }:
 
-# Update a macOS machine with nix-darwin
-#
-# Use the nix-darwin installer first, then base the configuration off the
-# generated ~/.nixpkgs/darwin-configuration.nix.
-args@{
-
-  # Source of nix-darwin
-  nix-darwin,
-
-  # Named parameters for call-ssh.nix
-  ssh,
-
-  # Configuration module; file path or module expression
-  # Start with a copy of ~/.nixpkgs/darwin-configuration.nix
-  configuration,
-
-  # Source of nixpkgs
-  nixpkgs ? path,
-
-  # System, defaults to x86_64-darwin
-  system,
-
-  passthru ? {},
-
-  # Remaining arguments are passed directly to mkEffect / mkDerivation
-  ...
-}:
 let
-  conf =
-    import nix-darwin {
-      inherit nixpkgs system configuration;
-    };
+  docUrl = "https://docs.hercules-ci.com/hercules-ci-effects/reference/nix-functions/runnixdarwin";
+
+  isRequired = param: throw ''
+    runNixDarwin: the argument ${param} wasn't specified. You must pass either:
+     - nix-darwin, nixpkgs, system and configuration,
+     - or config
+
+    See ${docUrl}
+  '';
+  mutExMsg = this: that: ''
+    runNixDarwin: the argument ${this} is mutually exclusive with ${that}.
+
+    See ${docUrl}
+  '';
+in
+
+# See https://docs.hercules-ci.com/hercules-ci-effects/reference/nix-functions/runnixdarwin
+  # or docs/modules/ROOT/pages/reference/nix-functions/runNixDarwin.adoc
+args@{
+  # Configuration parameters
+  nix-darwin ? isRequired "nix-darwin"
+, configuration ? isRequired "configuration"
+, nixpkgs ? isRequired "nixpkgs"
+, system ? isRequired "system"
+, config ? (import nix-darwin {
+    inherit nixpkgs system configuration;
+  }).config
+, # Deployment parameters
+  ssh
+, # Misc, optional
+  passthru ? { }
+, ...
+}:
+let _config = config;
+in
+let
+  config = if _config?config.system.build.toplevel then _config.config else _config;
 
   suffix =
     if args ? name
     then "-${args.name}"
-    else if conf.config.networking.hostName == null
+    else if config.networking.hostName or null == null
     then ""
-    else "-${conf.config.networking.hostName}";
+    else "-${config.networking.hostName}";
+
+  toplevel = config.system.build.toplevel;
+
+  profilePath = config.system.profile;
+
+  mutEx = this: that: lib.throwIf (args?${this} && args?${that}) (mutExMsg this that);
+
 in
-mkEffect (removeAttrs args ["configuration" "ssh"] // {
+
+mutEx "config" "configuration"
+mutEx "config" "nixpkgs"
+mutEx "config" "nix-darwin"
+mutEx "config" "system"
+
+mkEffect (removeAttrs args [ "configuration" "ssh" "config" "system" "nix-darwin" "nixpkgs" ] // {
   name = "nix-darwin${suffix}";
   inputs = [ openssh ];
   dontUnpack = true;
   passthru = passthru // {
-    prebuilt = conf.system // { inherit (conf) config; };
-    inherit (conf) config;
+    prebuilt = toplevel // { inherit config; };
+    inherit config;
   };
   effectScript = ''
     ${effects.ssh ssh ''
       set -eu
       echo >&2 "remote nix version:"
       nix-env --version >&2
-      if [ "$USER" != root ] && [ ! -w $(dirname "${conf.config.system.profile}") ]; then
-        sudo nix-env -p ${conf.config.system.profile} --set ${conf.system}
+      if [ "$USER" != root ] && [ ! -w $(dirname "${profilePath}") ]; then
+        sudo nix-env -p ${profilePath} --set ${toplevel}
       else
-        nix-env -p ${conf.config.system.profile} --set ${conf.system}
+        nix-env -p ${profilePath} --set ${toplevel}
       fi
-      ${conf.system}/sw/bin/darwin-rebuild activate
+      ${toplevel}/sw/bin/darwin-rebuild activate
     ''}
   '';
 })

--- a/effects/nix-darwin/test/configuration.nix
+++ b/effects/nix-darwin/test/configuration.nix
@@ -1,0 +1,14 @@
+{ lib, pkgs, ... }:
+{
+  environment.systemPackages = [ pkgs.hello ];
+  services.nix-daemon.enable = true;
+  nix.package = pkgs.nix;
+
+  # Paper over some flake vs non-flake differences so that the tests can compare toplevel
+  system.darwinVersionSuffix = lib.mkForce "TEST-DARWIN-VERSION-SUFFIX";
+  system.darwinRevision = lib.mkForce "TEST-DARWIN-REVISION";
+  system.nixpkgsRevision = lib.mkForce "TEST-NIXPKGS-REVISION";
+  system.nixpkgsVersion = lib.mkForce "TEST-NIXPKGS-VERSION";
+  system.nixpkgsVersionSuffix = lib.mkForce "TEST-NIXPKGS-VERSION-SUFFIX";
+  system.checks.verifyNixPath = lib.mkForce false;
+}

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -18,6 +18,10 @@ top@{ withSystem, lib, inputs, config, ... }: {
       evaluation-mkHerculesCI =
         let it = (import ./lib/mkHerculesCI-test.nix { inherit inputs; });
         in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };
+
+      evaluation-nix-darwin =
+        let it = (import ./effects/nix-darwin/eval-test.nix { inherit inputs; });
+        in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };
     };
 
     tests = withSystem "x86_64-linux" ({ hci-effects, pkgs, ... }: {


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->

Make `runNixDarwin` work with pre-evaluated configurations, such as in flakes.






<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
   - n/a