### PR TITLE
open more customization options for flake-update

### DIFF
--- a/effects/effect/effect-module.nix
+++ b/effects/effect/effect-module.nix
@@ -185,5 +185,6 @@ in
 
     extraAttributes.tests.buildable =
       (config.effectDerivation.overrideAttrs (o: { isEffect = false; })).inputDerivation;
+    extraAttributes.config = config;
   };
 }

--- a/effects/flake-update/effect-fun.nix
+++ b/effects/flake-update/effect-fun.nix
@@ -14,6 +14,8 @@ in
 , forgeType ? "github"
 , createPullRequest ? true
 , autoMergeMethod ? null
+, pullRequestTitle
+, pullRequestBody
 }:
 assert createPullRequest -> forgeType == "github";
 assert (autoMergeMethod != null) -> forgeType == "github";
@@ -29,14 +31,8 @@ modularEffect {
 
   git.update.branch = updateBranch;
   git.update.pullRequest.enable = createPullRequest;
-  git.update.pullRequest.title = "`flake.lock`: Update";
-  git.update.pullRequest.body = ''
-    Update `flake.lock`. See the commit message(s) for details.
-
-    You may reset this branch by deleting it and re-running the update job.
-
-        git push origin :${updateBranch}
-  '';
+  git.update.pullRequest.title = pullRequestTitle;
+  git.update.pullRequest.body = pullRequestBody;
   git.update.pullRequest.autoMergeMethod = autoMergeMethod;
 
   secretsMap.token = tokenSecret;

--- a/effects/flake-update/effect-fun.nix
+++ b/effects/flake-update/effect-fun.nix
@@ -54,7 +54,7 @@ modularEffect {
     command = if isSet then "flake lock" else "flake update";
   in ''
     echo 1>&2 'Running nix ${command}...'
-    nix ${command} ${optionalString isSet extraArgs} \
+    nix ${command} ${extraArgs} \
       --commit-lock-file \
       ${optionalString hasSummary "--commit-lockfile-summary \"${commitSummary}\""} \
       --extra-experimental-features 'nix-command flakes'

--- a/effects/flake-update/effect-fun.nix
+++ b/effects/flake-update/effect-fun.nix
@@ -48,10 +48,9 @@ modularEffect {
 
   git.update.script =
   let
-    isSet = inputs != [];
     hasSummary = commitSummary != "";
     extraArgs = concatStringsSep " " (forEach inputs (i: "--update-input ${i}"));
-    command = if isSet then "flake lock" else "flake update";
+    command = if inputs != [] then "flake lock" else "flake update";
   in ''
     echo 1>&2 'Running nix ${command}...'
     nix ${command} ${extraArgs} \

--- a/effects/flake-update/effect-fun.nix
+++ b/effects/flake-update/effect-fun.nix
@@ -18,6 +18,7 @@ in
 , pullRequestTitle
 , pullRequestBody
 , inputs ? []
+, commitSummary ? ""
 }:
 assert createPullRequest -> forgeType == "github";
 assert (autoMergeMethod != null) -> forgeType == "github";
@@ -47,12 +48,14 @@ modularEffect {
   git.update.script =
   let
     isSet = inputs != [];
+    hasSummary = commitSummary != "";
     extraArgs = concatStringsSep " " (forEach inputs (i: "--update-input ${i}"));
     command = if isSet then "flake lock" else "flake update";
   in ''
     echo 1>&2 'Running nix ${command}...'
     nix ${command} ${optionalString isSet extraArgs} \
       --commit-lock-file \
+      ${optionalString hasSummary "--commit-lockfile-summary \"${commitSummary}\""} \
       --extra-experimental-features 'nix-command flakes'
   '';
 

--- a/effects/flake-update/effect-fun.nix
+++ b/effects/flake-update/effect-fun.nix
@@ -15,8 +15,9 @@ in
 , forgeType ? "github"
 , createPullRequest ? true
 , autoMergeMethod ? null
-, pullRequestTitle
-, pullRequestBody
+  # NB: Default also specified in ./flake-module.nix
+, pullRequestTitle ? "`flake.lock`: Update"
+, pullRequestBody ? null
 , inputs ? []
 , commitSummary ? ""
 }:

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -81,7 +81,7 @@ in
     };
 
     pullRequestBody = mkOption {
-      type = types.str;
+      type = types.nullOr types.str;
       default = ''
         Update `flake.lock`. See the commit message(s) for details.
 

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -1,4 +1,4 @@
-{ config, lib, withSystem, ... }:
+{ config, lib, withSystem, self, ... }:
 let
   inherit (lib) mkOption types optionalAttrs;
   cfg = config.hercules-ci.flake-update;
@@ -70,6 +70,30 @@ in
         The [system](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-system) on which to run the flake update job.
       '';
     };
+
+    pullRequestTitle = mkOption {
+      type = types.str;
+      default = "`flake.lock`: Update";
+      example = "chore: update flake.lock";
+      description = ''
+        The title of the pull request being made
+      '';
+    };
+
+    pullRequestBody = mkOption {
+      type = types.str;
+      default = ''
+        Update `flake.lock`. See the commit message(s) for details.
+
+        You may reset this branch by deleting it and re-running the update job.
+
+            git push origin :${cfg.updateBranch}
+      '';
+      example = "updated flake.lock";
+      description = ''
+        The body of the pull request being made
+      '';
+    };
   };
 
   config = {
@@ -82,7 +106,7 @@ in
               hci-effects.flakeUpdate {
                 gitRemote = herculesCI.config.repo.remoteHttpUrl;
                 user = "x-access-token";
-                inherit (cfg) updateBranch forgeType createPullRequest autoMergeMethod;
+                inherit (cfg) updateBranch forgeType createPullRequest autoMergeMethod pullRequestTitle pullRequestBody;
               }
             );
           };

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -1,4 +1,4 @@
-{ config, lib, withSystem, self, ... }:
+{ config, lib, withSystem, ... }:
 let
   inherit (lib) mkOption types optionalAttrs;
   cfg = config.hercules-ci.flake-update;
@@ -94,6 +94,15 @@ in
         The body of the pull request being made
       '';
     };
+
+    inputs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ''["nixpkgs" "nixpkgs-unstable"]'';
+        description = ''
+          Flake inputs to update
+        '';
+    };
   };
 
   config = {
@@ -106,7 +115,7 @@ in
               hci-effects.flakeUpdate {
                 gitRemote = herculesCI.config.repo.remoteHttpUrl;
                 user = "x-access-token";
-                inherit (cfg) updateBranch forgeType createPullRequest autoMergeMethod pullRequestTitle pullRequestBody;
+                inherit (cfg) updateBranch forgeType createPullRequest autoMergeMethod pullRequestTitle pullRequestBody inputs;
               }
             );
           };

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -96,12 +96,21 @@ in
     };
 
     inputs = mkOption {
-        type = types.listOf types.str;
-        default = [];
-        example = ''["nixpkgs" "nixpkgs-unstable"]'';
-        description = ''
-          Flake inputs to update
-        '';
+      type = types.listOf types.str;
+      default = [];
+      example = ''["nixpkgs" "nixpkgs-unstable"]'';
+      description = ''
+        Flake inputs to update
+      '';
+    };
+
+    commitSummary = mkOption {
+      type = types.str;
+      default = "";
+      example = "chore: update flake inputs";
+      description = ''
+        Summary for commit
+      '';
     };
   };
 
@@ -115,7 +124,7 @@ in
               hci-effects.flakeUpdate {
                 gitRemote = herculesCI.config.repo.remoteHttpUrl;
                 user = "x-access-token";
-                inherit (cfg) updateBranch forgeType createPullRequest autoMergeMethod pullRequestTitle pullRequestBody inputs;
+                inherit (cfg) updateBranch forgeType createPullRequest autoMergeMethod pullRequestTitle pullRequestBody inputs commitSummary;
               }
             );
           };

--- a/effects/flake-update/test-module-eval.nix
+++ b/effects/flake-update/test-module-eval.nix
@@ -1,0 +1,87 @@
+args@
+{ inputs ? hercules-ci-effects.inputs
+, hercules-ci-effects ? if args?inputs then inputs.self else builtins.getFlake "git+file://${toString ./../..}"
+}:
+let
+  testSupport = import ../../lib/testSupport.nix args;
+in
+rec {
+  inherit (inputs) flake-parts nixpkgs;
+  inherit (nixpkgs) lib;
+  inherit (testSupport) callFlakeOutputs;
+
+  fakeRepoBranch = {
+    branch = "main";
+    ref = "refs/heads/main";
+    rev = "deadbeef";
+    shortRev = "deadbe";
+    tag = null;
+    remoteHttpUrl = "https://git.forge/repo.git";
+  };
+  fakeRepoTag = {
+    branch = null;
+    ref = "refs/heads/main";
+    rev = "deadbeef";
+    shortRev = "deadbe";
+    tag = "1.0";
+    remoteHttpUrl = "https://git.forge/repo.git";
+  };
+  fakeHerculesCI = repo: {
+    primaryRepo = repo;
+    inherit (repo) branch ref tag rev shortRev remoteHttpUrl;
+  };
+
+  basicUpdateOutputs =
+    callFlakeOutputs (inputs:
+      flake-parts.lib.mkFlake { inherit inputs; }
+      ({ ... }: {
+        imports = [
+          ../../flake-module.nix
+        ];
+        systems = ["x86_64-linux"];
+        hercules-ci.flake-update.enable = true;
+        hercules-ci.flake-update.when = { hour = 23; minute = 59; };
+      })
+    );
+  basicUpdateHerculesCI = basicUpdateOutputs.herculesCI (fakeHerculesCI fakeRepoBranch);
+  basicUpdateConfig = basicUpdateHerculesCI.onSchedule.flake-update.outputs.effects.flake-update.config;
+
+  subflakeUpdateOutputs =
+    callFlakeOutputs (inputs:
+      flake-parts.lib.mkFlake { inherit inputs; }
+      ({ ... }: {
+        imports = [
+          ../../flake-module.nix
+        ];
+        systems = ["x86_64-linux"];
+        hercules-ci.flake-update.enable = true;
+        hercules-ci.flake-update.when = { hour = 23; minute = 59; };
+        hercules-ci.flake-update.flakes = { "subflake" = { inputs = ["nixpkgs"]; }; };
+      })
+    );
+  subflakeUpdateHerculesCI = subflakeUpdateOutputs.herculesCI (fakeHerculesCI fakeRepoBranch);
+  subflakeUpdateConfig = subflakeUpdateHerculesCI.onSchedule.flake-update.outputs.effects.flake-update.config;
+
+  matches = regex: string: builtins.match regex string != null;
+  contains = substring: matches ".*${lib.escapeRegex substring}.*";
+
+  # How the root flake reference is rendered in the script.
+  rootFlakeRef = "'./.'";
+
+  tests = ok:
+    
+    assert basicUpdateHerculesCI.onSchedule.flake-update.when ==
+      { dayOfMonth = null; dayOfWeek = null; hour = [ 23 ]; minute = 59; };
+
+    assert contains rootFlakeRef basicUpdateConfig.git.update.script;
+
+    assert contains "'./subflake'" subflakeUpdateConfig.git.update.script;
+    # The default (flake at root) is overridden by the user definition. Potentially not future proof because it could match some other './.' substring.
+    assert ! contains rootFlakeRef subflakeUpdateConfig.git.update.script;
+
+    assert contains "--update-input nixpkgs" subflakeUpdateConfig.git.update.script;
+
+    ok;
+
+}
+

--- a/effects/flake-update/test.nix
+++ b/effects/flake-update/test.nix
@@ -26,6 +26,14 @@ effectVMTest {
       # TODO add test case for non-empty body
       # TODO add test case for empty body
     };
+    update-dep2input = hci-effects.flakeUpdate {
+      gitRemote = "http://gitea:3000/test/repo";
+      user = "test";
+      forgeType = "gitea";
+      createPullRequest = false;
+      commitSummary = "Update dep2input with custom message";
+      inputs = ["dep2input"];
+    };
   };
 
   testCases = ''
@@ -48,6 +56,14 @@ effectVMTest {
     """)
     print(dep)
 
+    dep2 = client.succeed("""
+      curl -v --fail -X POST http://gitea:3000/api/v1/user/repos \
+        -H 'Accept: application/json' -H 'Content-Type: application/json' \
+        """ + f"-H 'Authorization: token {token}'" + """ \
+        -d '{"name":"dep2", "private":true}'
+    """)
+    print(dep2)
+
     dep_commits = client.succeed("""
     (
     git clone http://gitea:3000/test/dep.git
@@ -58,12 +74,25 @@ effectVMTest {
     git push
     cd ..
 
+    git clone http://gitea:3000/test/dep2.git
+    cd dep2
+    touch file
+    git add file
+    git commit -m 'init dep2'
+    git push
+    cd ..
+
     git clone http://gitea:3000/test/repo.git
     cd repo
     cat >flake.nix <<EOF
     {
       inputs.dep = {
         url = "git+http://gitea:3000/test/dep";
+        flake = false;
+      };
+      # a different input name as opposed to repo name
+      inputs.dep2input = {
+        url = "git+http://gitea:3000/test/dep2";
         flake = false;
       };
       outputs = { ... }: {
@@ -127,12 +156,12 @@ effectVMTest {
         )
     """)
 
-    with subtest("Works when pullRequest body is empty"):
-
-      depRev = client.succeed("""
+    # repoName: name of the repo checkout directory on `client`
+    def updateRepo(repoName):
+      return client.succeed(f"""
         (
           set -x
-          cd dep
+          cd {repoName}
           git log
           echo changed >>file
           git add file
@@ -142,8 +171,12 @@ effectVMTest {
           cd ../repo
           git log
         ) 1>&2
-        (cd dep; git rev-parse HEAD)
+        (cd {repoName}; git rev-parse HEAD)
       """).rstrip()
+
+    with subtest("Works when pullRequest body is empty"):
+
+      depRev = updateRepo("dep")
       agent.succeed(f"echo {gitea_admin_password} | effect-update-no-pr-body")
       # FIXME: actually enable pull request for this effect, using a different backend, and/or by implementing it for gitea (useless for now), and check that it is created
       client.succeed(f"""
@@ -153,6 +186,22 @@ effectVMTest {
           git pull
           git log
           grep {depRev} <flake.lock
+        ) 1>&2
+      """)
+
+    with subtest("Can select specific input to update"):
+      depRev = updateRepo("dep")
+      dep2Rev = updateRepo("dep2")
+      agent.succeed(f"echo {gitea_admin_password} | effect-update-dep2input")
+      client.succeed(f"""
+        (
+          set -x
+          cd repo
+          git pull
+          git log
+          git log | grep "Update dep2input with custom message"
+          ! grep {depRev} <flake.lock
+          grep {dep2Rev} <flake.lock
         ) 1>&2
       """)
   '';

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -15,6 +15,10 @@ top@{ withSystem, lib, inputs, config, ... }: {
         let it = (import ./flake-modules/herculesCI-eval-test.nix { inherit inputs; });
         in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };
 
+      evaluation-flake-update =
+        let it = (import ./effects/flake-update/test-module-eval.nix { inherit inputs; });
+        in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };
+
       evaluation-mkHerculesCI =
         let it = (import ./lib/mkHerculesCI-test.nix { inherit inputs; });
         in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->
i've been using flake-update for a while now, and it was honestly a much better way to manage input updates than my own github workflow solutions. recently though, i've started to use more inputs for things like packages, overlays, etc. and because of this, i want to update only some inputs at one time and others at another. looking through the documentation and the source, i found no way to do this currently and started looking to other options like determinate system's [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) action. but after looking through the modules more, i thought it might be a good idea to just add a similar ability here (and more!) since the integration with the rest of hercules-ci is too good to pass up on


two features are introduced here:
 - options to set custom pull request titles and bodies
   - most other input update methods include this (such as the aforementioned determinate systems action), as it's a nice way to integrate with other ci tools or just organize things the way you would like
   - ~~i would also like to expose an option for the commit title here as well, but i can't really find where that's specified or how to change it~~ implemented! see below :)
 - options to set specific inputs to update
   - self-explanatory. might be a niche use case, but i still think it'd be nice nonetheless
 - option to set arbitrary commit summaries
   - i didn't think this was possible with `--commit-lock-file`, but i recently found `--commit-lockfile-summary`, which allows us to open this up as an option
   
[here](https://hercules-ci.com/github/getchoo/flake/jobs/223) is a successful run using 918c993, and the resulting [pull request](https://github.com/getchoo/flake/pull/24)

[here](https://hercules-ci.com/github/getchoo/flake/jobs/238) is a successful run using 1bcdb1e, and the resulting [pull request](https://github.com/getchoo/flake/pull/26)

[here](https://hercules-ci.com/github/getchoo/flake/jobs/273) is a successful run using 7888b27, and the resulting [pull request](https://github.com/getchoo/flake/pull/31)

the configuration for the effect can be found in `modules/flake/ci.nix`



<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [ ] Documentation (function reference docs, setup guide, option reference docs)
 - [ ] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
