### PR TITLE
Expose effect modules, use `hci-effects` name instead of just `effects`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,5 +8,7 @@
  */
 
 { pkgs }: rec {
-  effects = import ./effects/default.nix effects pkgs;
+  effects = hci-effects;
+  hci-effects = import ./effects/default.nix effects pkgs;
+  modules = import ./effects/modules.nix;
 }

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -10,7 +10,7 @@
 ** xref:guide/write-a-custom-effect.adoc[Write a Custom Effect]
 ** xref:guide/deploy-to-github-pages.adoc[Deploy to GitHub Pages]
 ** xref:guide/distribute-a-static-binary-with-github-releases.adoc[Distribute a Static Binary with GitHub Releases]
-* Effect Module Reference
+* xref:reference/effect-modules.adoc[Effect Module Reference]
 ** xref:reference/effect-modules/core.adoc[Core Options]
 ** xref:reference/effect-modules/git.adoc[Git Options]
 * Flake Parts Module Reference

--- a/docs/modules/ROOT/pages/guide/import-or-pin.adoc
+++ b/docs/modules/ROOT/pages/guide/import-or-pin.adoc
@@ -29,10 +29,12 @@ In your outputs section:
         hercules-ci-effects.flakeModule
       ];
 
-      effects = { branch, ... }: withSystem "x86_64-linux" (
-        { config, effects, pkgs, inputs', ... }:
+      # flake.effects is added as onPush.default.outputs.
+      # For full flexibility, instead use https://flake.parts/options/hercules-ci-effects.html#opt-herculesCI
+      flake.effects = { branch, ... }: withSystem "x86_64-linux" (
+        { config, hci-effects, pkgs, inputs', ... }:
         {
-          deploy = effects.runNixOS {
+          deploy = hci-effects.runNixOS {
             # ...
           };
         }
@@ -102,7 +104,7 @@ Define the `herculesCI` flake output attribute. Here's a complete example:
         };
 
         # Some modules have options in `perSystem`
-        perSystem = { system, ... } = {
+        perSystem = { system, hci-effects, ... } = {
           # Many flakes call Nixpkgs, to set some `config` or `overlays`.
           # If yours needs that, it's best to reuse your pkgs here. Example:
           # _module.args.pkgs = pkgsFor.${system};
@@ -135,9 +137,9 @@ In your outputs section, call Nixpkgs with the overlay:
           hercules-ci-effects.overlay
         ];
       };
-      inherit (pkgs) effects; # optional
+      inherit (pkgs) hci-effects; # optional
     in {
-      # your flake attributes, using `pkgs.effects` or `effects` (optional)
+      # your flake attributes, using `pkgs.hci-effects` or `hci-effects` (optional)
     }
 ```
 
@@ -160,7 +162,7 @@ Call `hercules-ci-effects`:
   outputs = { hercules-ci-effects, ... }:
     let
       pkgs = /* ... */;
-      effects = hercules-ci-effects.lib.withPkgs pkgs;
+      hci-effects = hercules-ci-effects.lib.withPkgs pkgs;
     in {
       # your flake attributes, using `effects`
     }

--- a/docs/modules/ROOT/pages/reference/effect-modules.adoc
+++ b/docs/modules/ROOT/pages/reference/effect-modules.adoc
@@ -1,0 +1,12 @@
+
+# Effect Modules
+
+While the low-level primitive for constructing xref:index.adoc[Effects], xref:reference/nix-functions/mkEffect.adoc[`mkEffect`], is based on `mkDerivation`, we use the module system to build a more convenient interface for defining effects.
+
+You may consume these modules indirectly through `flake-parts` modules or functions such as xref:reference/nix-functions/flakeUpdate.adoc[`flakeUpdate`], or you can turn them into effects yourself using xref:reference/nix-functions/modularEffect.adoc[`modularEffect`].
+
+The modules each have an attribute in `hci-effects.modules` and `modules.effect` in the flake. The examples will use `hci-effects.modules` which is usually most convenient.
+
+If you publish your own effect modules, you can import from `inputs.hercules-ci-effects.modules.effect.*`, so that your modules do not have to be in an unnecessary function that takes `hci-effects` and/or `pkgs` as an argument.
+
+Use the navigation menu to find the available modules.

--- a/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
+++ b/docs/modules/ROOT/pages/reference/effect-modules/git.adoc
@@ -5,12 +5,32 @@
 
 The module provides the basics for working with a git repository.
 
+Example import:
+
+```nix
+hci-effects.modularEffect {
+  imports = [
+    hci-effects.modules.git-auth
+  ];
+}
+```
+
 include::partial$options/git-auth.adoc[leveloffset=0]
 
 [[git-update]]
 ## `git-update`
 
 A module that facilitates the updating of a git repository.
+
+Example import:
+
+```nix
+hci-effects.modularEffect {
+  imports = [
+    hci-effects.modules.git-update
+  ];
+}
+```
 
 include::partial$options/git-update.adoc[leveloffset=0]
 

--- a/docs/modules/ROOT/pages/reference/nix-functions/modularEffect.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/modularEffect.adoc
@@ -3,6 +3,22 @@
 
 This function is a module system-based wrapper for xref:reference/nix-functions/mkEffect.adoc[`mkEffect`]. The module systemfootnote:[The _module system_ refers to the module system used by NixOS. It does not include anything specific to NixOS, but rather the features such as `imports`, types, `mkForce`, etc.] helps effect logic to be composed, factored out and reused. `hercules-ci-effects` provides a number of modules to be imported.
 
+[[example]]
+## Example
+
+```nix
+hci-effects.modularEffect ({ pkgs, ... }: {
+  imports = [ hci-effects.modules.git-auth ];
+  inputs = [ pkgs.hello ]
+  effectScript = ''
+    hello
+    git status
+  '';
+})
+```
+
+For `hci-effects`, see xref:guide/import-or-pin.adoc[Import `hercules-ci-effects`].
+
 [[parameter]]
 ## Parameter
 

--- a/effects/default.nix
+++ b/effects/default.nix
@@ -46,6 +46,8 @@ checkVersion
       ];
     });
 
+  modules = import ./modules.nix;
+
   runIf = condition: v:
     recurseIntoAttrs (
       (

--- a/effects/modules.nix
+++ b/effects/modules.nix
@@ -1,0 +1,37 @@
+/*
+  Modules for use in `modularEffect`.
+
+  Flake:
+
+      hercules-ci-effects.modules.effect.*
+
+  Alternative:
+
+      hci-effects.modules.*
+
+*/
+{
+  /*
+    Git authentication
+
+    See https://docs.hercules-ci.com/hercules-ci-effects/reference/effect-modules/git#git-auth
+  */
+  git-auth = ./effects/modules/git-auth.nix;
+
+  /*
+    GitHub authentication for the `gh` command. Not needed if you only use git.
+  */
+  git-auth-gh = ./effects/modules/git-auth-gh.nix;
+
+  /*
+    Logic for updating a git branch.
+
+    See https://docs.hercules-ci.com/hercules-ci-effects/reference/effect-modules/git#git-update
+  */
+  git-update = ./effects/modules/git-auth.nix;
+
+  /*
+    Very basic git configuration; default author, adding git to PATH, etc.
+  */
+  git = ./effects/modules/git.nix;
+}

--- a/flake-public-outputs.nix
+++ b/flake-public-outputs.nix
@@ -1,4 +1,4 @@
-{ withSystem, inputs, ... }: {
+{ withSystem, inputs, lib, ... }: {
   imports = [
     ./flake-module.nix
     ./flake-docs-render.nix
@@ -21,7 +21,8 @@
     };
 
     overlay = final: prev: {
-      effects = import ./effects/default.nix final.effects final;
+      effects = lib.warn "pkgs.effects is deprecated. Use pkgs.hci-effects instead." final.hci-effects;
+      hci-effects = import ./effects/default.nix final.effects final;
     };
 
     templates = rec {

--- a/flake-public-outputs.nix
+++ b/flake-public-outputs.nix
@@ -14,6 +14,12 @@
 
     lib.mkHerculesCI = import ./lib/mkHerculesCI.nix inputs;
 
+    modules = {
+      # Also available as `(lib.withPkgs pkgs).modules` aka
+      # `hci-effects.modules` when using flake-parts `perSystem` module argument.
+      effects = import ./effects/modules.nix;
+    };
+
     overlay = final: prev: {
       effects = import ./effects/default.nix final.effects final;
     };


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->

Expose the `modularEffect` modules properly with attributes.

Use the `hci-effects` name consistently and improve docs.


<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)
 - [ ] Has tests (VM test, free account, and/or test instructions)
    - manually tested the entrypoints
 - [x] Is the corresponding module up to date?
