### PR TITLE
git-update / flake-update: keep branch up to date with `baseMerge`

### DIFF
--- a/effects/flake-update/effect-fun.nix
+++ b/effects/flake-update/effect-fun.nix
@@ -28,6 +28,9 @@ passedArgs@
   # NB: Default also specified in ./flake-module.nix
 , pullRequestTitle ? genTitle flakes
 , pullRequestBody ? null
+  # TODO [baseMerge] "HEAD" by default instead of null after real world testing
+, baseMergeBranch ? null
+, baseMergeMethod ? "merge"
 , flakes ? { "." = { inherit inputs commitSummary; }; }
 , inputs ? [ ]
 , commitSummary ? ""
@@ -60,6 +63,9 @@ modularEffect {
   git.update.pullRequest.title = pullRequestTitle;
   git.update.pullRequest.body = pullRequestBody;
   git.update.pullRequest.autoMergeMethod = autoMergeMethod;
+  git.update.baseMerge.branch = lib.mkIf (baseMergeBranch != null) (lib.mkDefault baseMergeBranch);
+  git.update.baseMerge.method = lib.mkDefault baseMergeMethod;
+  git.update.baseMerge.enable = lib.mkDefault (baseMergeMethod != null && baseMergeBranch != null);
 
   secretsMap.token = tokenSecret;
 

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -50,6 +50,19 @@ in
       '';
     };
 
+    baseBranch = mkOption {
+      type = types.str;
+      default = "HEAD";
+      example = "develop";
+      description = ''
+        Branch name on the remote that the update branch will be
+          - based on (via `hercules-ci.flake-update.baseMerge.branch`), and
+          - merged back into if `hercules-ci.flake-update.createPullRequest` is enabled.
+
+        `"HEAD"` refers to the default branch, which is often `main` or `master`.
+      '';
+    };
+
     forgeType = mkOption {
       type = types.str;
       default = "github";
@@ -64,6 +77,8 @@ in
         Whether to merge the base branch into the update branch before running the update.
 
         This is useful to ensure that the update branch is up to date with the base branch.
+
+        If this option is `false`, you may have to merge or rebase the update branch manually sometimes.
       '';
       type = types.bool;
       default = false;
@@ -76,7 +91,8 @@ in
         Used when `hercules-ci.flake-update.baseMerge.enable` is true.
       '';
       type = types.str;
-      default = "HEAD";
+      default = cfg.baseBranch;
+      defaultText = lib.literalExpression "hercules-ci.flake-update.baseBranch";
     };
 
     baseMerge.method = mkOption {
@@ -182,6 +198,7 @@ in
   config = {
     hercules-ci.flake-update.effect.settings = {
       git.update.baseMerge = cfg.baseMerge;
+      git.update.baseBranch = cfg.baseBranch;
     };
     herculesCI = herculesCI@{ config, ... }: optionalAttrs (cfg.enable) {
       onSchedule.flake-update = {

--- a/effects/flake-update/flake-module.nix
+++ b/effects/flake-update/flake-module.nix
@@ -59,6 +59,36 @@ in
       '';
     };
 
+    baseMerge.enable = mkOption {
+      description = ''
+        Whether to merge the base branch into the update branch before running the update.
+
+        This is useful to ensure that the update branch is up to date with the base branch.
+      '';
+      type = types.bool;
+      default = false;
+    };
+
+    baseMerge.branch = mkOption {
+      description = ''
+        Branch name on the remote to merge into the update branch before running the update.
+
+        Used when `hercules-ci.flake-update.baseMerge.enable` is true.
+      '';
+      type = types.str;
+      default = "HEAD";
+    };
+
+    baseMerge.method = mkOption {
+      description = ''
+        How to merge the base branch into the update branch before running the update.
+
+        Used when `hercules-ci.flake-update.baseMerge.enable` is true.
+      '';
+      type = types.enum [ "merge" "rebase" ];
+      default = "merge";
+    };
+
     createPullRequest = mkOption {
       type = types.bool;
       default = true;
@@ -150,6 +180,9 @@ in
   };
 
   config = {
+    hercules-ci.flake-update.effect.settings = {
+      git.update.baseMerge = cfg.baseMerge;
+    };
     herculesCI = herculesCI@{ config, ... }: optionalAttrs (cfg.enable) {
       onSchedule.flake-update = {
         inherit (cfg) when;

--- a/effects/modules/git-update.nix
+++ b/effects/modules/git-update.nix
@@ -151,7 +151,7 @@ in
     // optionalAttrs (cfg.pullRequest.enable && cfg.pullRequest.body != null) {
       HCI_GIT_UPDATE_PR_BODY = cfg.pullRequest.body;
     }
-    // optionalAttrs (cfg.baseMerge.enable) {
+    // optionalAttrs cfg.baseMerge.enable {
       HCI_GIT_UPDATE_BASE_MERGE_METHOD = cfg.baseMerge.method;
     };
 

--- a/effects/modules/git-update.nix
+++ b/effects/modules/git-update.nix
@@ -40,11 +40,24 @@ in
         '';
         type = types.lines;
       };
+      baseBranch = mkOption {
+        description = ''
+          Branch name on the remote that the update branch will be
+            - based on (via `git.update.baseMerge.branch`), and
+            - merged back into (via `git.update.pullRequest.base`) if enabled.
+
+          `"HEAD"` refers to the default branch, which is often `main` or `master`.
+        '';
+        type = types.str;
+        default = "HEAD";
+      };
       baseMerge.enable = mkOption {
         description = ''
           Whether to merge the base branch into the update branch before running `git.update.script`.
 
           This is useful to ensure that the update branch is up to date with the base branch.
+
+          If this option is `false`, you may have to merge or rebase the update branch manually sometimes.
         '';
         type = types.bool;
         # TODO [baseMerge] enable by default after real world testing
@@ -57,7 +70,10 @@ in
           Used when `git.update.baseMerge.enable` is true.
         '';
         type = types.str;
-        default = "HEAD";
+        default = cfg.baseBranch;
+        defaultText = lib.literalExpression ''
+          git.update.baseBranch
+        '';
       };
       baseMerge.method = mkOption {
         description = ''
@@ -83,7 +99,11 @@ in
             Used when `git.update.pullRequest.enable` is true.
           '';
           type = types.str;
-          default = "HEAD";
+          default = cfg.baseBranch;
+          defaultText = lib.literalExpression ''
+            git.update.baseBranch
+          '';
+          example = "develop";
         };
         autoMergeMethod = mkOption {
           type = types.enum [ null "merge" "rebase" "squash" ];

--- a/effects/modules/git-update.nix
+++ b/effects/modules/git-update.nix
@@ -142,6 +142,7 @@ in
     env = {
       HCI_GIT_REMOTE_URL = config.git.checkout.remote.url;
       HCI_GIT_UPDATE_BRANCH = cfg.branch;
+      HCI_GIT_UPDATE_BASE_BRANCH = cfg.baseMerge.branch;
     }
     // optionalAttrs cfg.pullRequest.enable {
       HCI_GIT_UPDATE_PR_TITLE = cfg.pullRequest.title;
@@ -151,7 +152,6 @@ in
       HCI_GIT_UPDATE_PR_BODY = cfg.pullRequest.body;
     }
     // optionalAttrs (cfg.baseMerge.enable) {
-      HCI_GIT_UPDATE_BASE_BRANCH = cfg.baseMerge.branch;
       HCI_GIT_UPDATE_BASE_MERGE_METHOD = cfg.baseMerge.method;
     };
 
@@ -162,18 +162,20 @@ in
         git checkout "$HCI_GIT_UPDATE_BRANCH"
         updateBranchExisted=true
       else
-        git checkout -b "$HCI_GIT_UPDATE_BRANCH"
+        git checkout -b "$HCI_GIT_UPDATE_BRANCH" "refs/remotes/origin/$HCI_GIT_UPDATE_BASE_BRANCH"
         updateBranchExisted=false
       fi
 
-      case "''${HCI_GIT_UPDATE_BASE_MERGE_METHOD:-}" in
-        merge)
-          git merge "refs/remotes/origin/$HCI_GIT_UPDATE_BASE_BRANCH"
-          ;;
-        rebase)
-          git rebase "refs/remotes/origin/$HCI_GIT_UPDATE_BASE_BRANCH"
-          ;;
-      esac
+      if [[ "$updateBranchExisted" == "true" ]]; then
+        case "''${HCI_GIT_UPDATE_BASE_MERGE_METHOD:-}" in
+          merge)
+            git merge "refs/remotes/origin/$HCI_GIT_UPDATE_BASE_BRANCH"
+            ;;
+          rebase)
+            git rebase "refs/remotes/origin/$HCI_GIT_UPDATE_BASE_BRANCH"
+            ;;
+        esac
+      fi
 
       rev_before="$(git rev-parse HEAD)"
 


### PR DESCRIPTION
### Motivation

Keep the update branch up to date.

If the CI fails on the update branch, we want to automatically pull from the main branch, as it may contain fixes.

This behavior is not enabled by default yet. Use e.g.

```nix
hercules-ci.flake-update.baseMerge.enable = true;
```


<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)\
    - will be default behavior, so no guide needed
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [x] Is the corresponding module up to date?
