### PR TITLE
ssh/NixOS/nix-darwin: add `ssh.buildOnDestination`

### DIFF
--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixDarwin.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixDarwin.adoc
@@ -34,6 +34,15 @@ hci-effects.runNixDarwin {
 [[parameters]]
 == Parameters
 
+
+[[param-buildOnDestination]]
+== `buildOnDestination`
+
+Default: value of `ssh.buildOnDestination`, which defaults to `false`.
+
+Overrides xref:reference/nix-functions/ssh.adoc#param-buildOnDestination[`ssh.buildOnDestination`]. Defer builds to the host instead of pre-building in CI.
+
+
 [[param-config]]
 === `config`
 

--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
@@ -63,15 +63,11 @@ See the named arguments in xref:reference/nix-functions/ssh.adoc[]. Example:
 [[param-system]]
 === `system`
 
-The Nix `system` of the machine to deploy.
+Optional, legacy.
 
-Example: `system = "x86_64-linux";`
+Preferably, this is set in the configuration itself, in `nixpkgs.hostPlatform`.
 
-Example: `system = "aarch64-linux";`
-
-See https://nixos.org/manual/nix/stable/#ch-supported-platforms[Nix supported platforms,role=external]
-
-Required, unless you pass the module system result via xref:param-config.
+`nixos-generate-config` sets that option automatically in `hardware-configuration.nix`.
 
 
 [[param-userSetupScript]]

--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
@@ -9,6 +9,14 @@ Deploy a NixOS configuration to a machine.
 == Parameters
 
 
+[[param-buildOnDestination]]
+== `buildOnDestination`
+
+Default: value of `ssh.buildOnDestination`, which defaults to `false`.
+
+Overrides xref:reference/nix-functions/ssh.adoc#param-buildOnDestination[`ssh.buildOnDestination`]. Defer builds to the host instead of pre-building in CI.
+
+
 [[param-config]]
 === `config`
 

--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
@@ -31,9 +31,12 @@ Example (Flakes): `configuration = self.nixosConfigurations.foo;`
 
 Required, unless you set xref:param-config, which is not the preferred solution.
 
+When this option is set to a pre-evaluated configuration, as in the latter example, xref:param-system[], xref:param-configuration[] and xref:param-nixpkgs[] are ignored.
 
 [[param-nixpkgs]]
 === `nixpkgs`
+
+Required when `configuration` is a module or file.
 
 Path of the Nixpkgs sources to use. These also include the NixOS sources.
 

--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
@@ -23,11 +23,13 @@ When this option is set, xref:param-system[], xref:param-configuration[] and xre
 [[param-configuration]]
 === `configuration`
 
-A NixOS configuration file or module.
+A NixOS configuration or module.
 
 Example: `configuration = ./configuration.nix;`
 
-Required, unless you invoke the module system yourself via xref:param-config.
+Example (Flakes): `configuration = self.nixosConfigurations.foo;`
+
+Required, unless you set xref:param-config, which is not the preferred solution.
 
 
 [[param-nixpkgs]]

--- a/docs/modules/ROOT/pages/reference/nix-functions/ssh.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/ssh.adoc
@@ -77,6 +77,30 @@ not been `export`-ed. Such variables remain un-`export`-ed.
 
 == Parameters
 
+[[param-buildOnDestination]]
+=== `buildOnDestination`
+
+Default: `false`. Whether to build the command and its dependencies on the remote.
+
+This is useful when bootstrapping a new agent without setting it up as a remote builder first.
+
+Builds that are deferred to the destination are by definition not built during the "build phase" of CI.
+This means that you may encounter a build failure after the job's effects are started.
+For this reason, you might want to enable this only temporarily, or you could add attributes to the job for relevant packages and checks.
+
+The latter option has the benefit that packages will be in your binary cache, to speed up realisation on the remote, similar to when `buildOnDestination` is `false`.
+
+[[param-destinationPkgs]]
+=== `destinationPkgs`
+
+Only needed when <<param-buildOnDestination>> is `true`.
+
+Some functions, such as `runNixDarwin` will set a default value for you.
+
+A Nixpkgs instance that is buildable on the destination.
+
+This parameter is part of a workaround for https://github.com/NixOS/nix/issues/5868#issuecomment-1757869475[no `builtins.storePath` in pure mode (nix issue)].
+
 [[param-compressClosure]]
 === `compressClosure`
 

--- a/docs/modules/ROOT/pages/reference/nix-functions/ssh.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/ssh.adoc
@@ -90,6 +90,8 @@ For this reason, you might want to enable this only temporarily, or you could ad
 
 The latter option has the benefit that packages will be in your binary cache, to speed up realisation on the remote, similar to when `buildOnDestination` is `false`.
 
+Evaluation still happens in CI, as well as builds for "import from derivation" if needed.
+
 [[param-destinationPkgs]]
 === `destinationPkgs`
 

--- a/effects/nix-darwin/eval-test.nix
+++ b/effects/nix-darwin/eval-test.nix
@@ -13,11 +13,7 @@ in
 rec {
   inherit darwin testSupport;
   inherit (inputs) flake-parts;
-  inherit (testSupport) callFlakeOutputs;
-
-  testEqDrv = drv1: drv2:
-    if drv1 == drv2 then true
-    else builtins.trace "Oh-oh, these are different! Check the differences with\nnix-diff --color=always ${drv1} ${drv2} | less -RS" false;
+  inherit (testSupport) callFlakeOutputs testEqDrv;
 
   flake1 = callFlakeOutputs (inputs:
     flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, self, ... }: {

--- a/effects/nix-darwin/eval-test.nix
+++ b/effects/nix-darwin/eval-test.nix
@@ -32,6 +32,38 @@ rec {
             config = self.darwinConfigurations."Johns-MacBook";
           }
         );
+        test.by-config-buildOnDestination = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixDarwin {
+            ssh.destination = "john.local";
+            # TODO make destinationPkgs obsolete
+            ssh.destinationPkgs = inputs.nixpkgs.legacyPackages.x86_64-darwin;
+            ssh.buildOnDestination = true;
+            config = self.darwinConfigurations."Johns-MacBook";
+          }
+        );
+        test.by-config-buildOnDestination-override = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixDarwin {
+            ssh.destination = "john.local";
+            # TODO make destinationPkgs obsolete
+            ssh.destinationPkgs = inputs.nixpkgs.legacyPackages.x86_64-darwin;
+            buildOnDestination = true;
+            config = self.darwinConfigurations."Johns-MacBook";
+          }
+        );
+        test.by-config-no-buildOnDestination = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixDarwin {
+            ssh.destination = "john.local";
+            buildOnDestination = false;
+            config = self.darwinConfigurations."Johns-MacBook";
+          }
+        );
+        test.by-config-no-ssh-buildOnDestination = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixDarwin {
+            ssh.destination = "john.local";
+            buildOnDestination = false;
+            config = self.darwinConfigurations."Johns-MacBook";
+          }
+        );
         test.by-other-args = withSystem "x86_64-linux" ({ hci-effects, ... }:
           hci-effects.runNixDarwin {
             ssh.destination = "john.local";
@@ -74,6 +106,21 @@ rec {
     # A custom pkgs should be used without reinvoking nixpkgs from scratch.
     assert
       flake1.test.by-other-args-pkgs.config.expose.pkgs.proof-of-overlay == "yes, overlay";
+
+    assert
+      testEqDrv
+        flake1.test.by-config.drvPath
+        flake1.test.by-config-no-buildOnDestination.drvPath;
+
+    assert
+      testEqDrv
+        flake1.test.by-config.drvPath
+        flake1.test.by-config-no-ssh-buildOnDestination.drvPath;
+
+    assert
+      testEqDrv
+        flake1.test.by-config-buildOnDestination.drvPath
+        flake1.test.by-config-buildOnDestination-override.drvPath;
 
     ok;
 

--- a/effects/nix-darwin/eval-test.nix
+++ b/effects/nix-darwin/eval-test.nix
@@ -32,6 +32,12 @@ rec {
             config = self.darwinConfigurations."Johns-MacBook";
           }
         );
+        test.by-config-legacy = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixDarwin {
+            ssh.destination = "john.local";
+            config = self.darwinConfigurations."Johns-MacBook".config;
+          }
+        );
         test.by-config-buildOnDestination = withSystem "x86_64-linux" ({ hci-effects, ... }:
           hci-effects.runNixDarwin {
             ssh.destination = "john.local";
@@ -94,6 +100,11 @@ rec {
 
     assert 
       testEqDrv flake1.test.by-config.drvPath flake1.test.by-other-args.drvPath;
+
+    assert
+      testEqDrv
+        flake1.test.by-config.drvPath
+        flake1.test.by-config-legacy.drvPath;
 
     assert
       builtins.isString flake1.test.by-other-args-pkgs.drvPath;

--- a/effects/nix-darwin/eval-test.nix
+++ b/effects/nix-darwin/eval-test.nix
@@ -41,8 +41,6 @@ rec {
         test.by-config-buildOnDestination = withSystem "x86_64-linux" ({ hci-effects, ... }:
           hci-effects.runNixDarwin {
             ssh.destination = "john.local";
-            # TODO make destinationPkgs obsolete
-            ssh.destinationPkgs = inputs.nixpkgs.legacyPackages.x86_64-darwin;
             ssh.buildOnDestination = true;
             config = self.darwinConfigurations."Johns-MacBook";
           }
@@ -50,8 +48,6 @@ rec {
         test.by-config-buildOnDestination-override = withSystem "x86_64-linux" ({ hci-effects, ... }:
           hci-effects.runNixDarwin {
             ssh.destination = "john.local";
-            # TODO make destinationPkgs obsolete
-            ssh.destinationPkgs = inputs.nixpkgs.legacyPackages.x86_64-darwin;
             buildOnDestination = true;
             config = self.darwinConfigurations."Johns-MacBook";
           }

--- a/effects/nix-darwin/eval-test.nix
+++ b/effects/nix-darwin/eval-test.nix
@@ -8,7 +8,7 @@ let
   # TODO: use a flake.lock, so that we can CI the upstream
   #       also lib.darwinSystem would need follows to inject our own nixpkgs,
   #       so we use the one from the nix-darwin flake for testing here. Awkward.
-  darwin = builtins.getFlake "github:LnL7/nix-darwin?rev=87b9d090ad39b25b2400029c64825fc2a8868943";
+  darwin = builtins.getFlake "github:LnL7/nix-darwin?rev=8b6ea26d5d2e8359d06278364f41fbc4b903b28a";
 in
 rec {
   inherit darwin testSupport;

--- a/effects/nix-darwin/run-nix-darwin.nix
+++ b/effects/nix-darwin/run-nix-darwin.nix
@@ -63,6 +63,9 @@ let
 
   mutEx = this: that: lib.throwIf (args?${this} && args?${that}) (mutExMsg this that);
 
+  # Add default value for destinationPkgs, for when buildOnDestination is true
+  ssh' = { destinationPkgs = config.options._module.args.value.pkgs; } // ssh;
+
 in
 
 mutEx "config" "configuration"
@@ -80,7 +83,7 @@ mkEffect (removeAttrs args [ "configuration" "ssh" "config" "system" "nix-darwin
     inherit config;
   };
   effectScript = ''
-    ${effects.ssh ssh ''
+    ${effects.ssh ssh' ''
       set -eu
       echo >&2 "remote nix version:"
       nix-env --version >&2

--- a/effects/nix-darwin/run-nix-darwin.nix
+++ b/effects/nix-darwin/run-nix-darwin.nix
@@ -68,9 +68,12 @@ let
 
   # Add default value for destinationPkgs, for when buildOnDestination is true
   ssh' = {
-      # non-standard
-      # destinationPkgs = config.options._module.args.value.pkgs;
-      destinationPkgs = throw "When buildOnDestination is true, you must specify destinationPkgs. See https://docs.hercules-ci.com/hercules-ci-effects/reference/nix-functions/ssh.html#param-buildOnDestination";
+      destinationPkgs =
+        _config._module.args.pkgs or (throw ''
+          When `buildOnDestination` is true, you must either specify a whole nix-darwin configuration attrset (not just `config = myConfiguration.config`, or you must specify `ssh.destinationPkgs`.
+
+          See also https://docs.hercules-ci.com/hercules-ci-effects/reference/nix-functions/ssh.html#param-buildOnDestination
+        '');
     }
     // ssh
     // optionalAttrs (buildOnDestination != null) {

--- a/effects/nixos/eval-test.nix
+++ b/effects/nixos/eval-test.nix
@@ -1,0 +1,73 @@
+args@
+{ inputs ? hercules-ci-effects.inputs
+, hercules-ci-effects ? if args?inputs then inputs.self else builtins.getFlake "git+file://${toString ../..}"
+}:
+let
+  testSupport = import ../../lib/testSupport.nix args;
+
+in
+rec {
+  inherit testSupport;
+  inherit (inputs) flake-parts;
+  inherit (testSupport) callFlakeOutputs;
+  inherit (inputs.nixpkgs) lib;
+
+  isEffect = x: x.isEffect == true && lib.isString x.drvPath;
+
+  flake1 = callFlakeOutputs (inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, self, ... }: {
+      imports = [
+        ../../flake-module.nix
+      ];
+      systems = [ "x86_64-linux" ];
+      flake = {
+        nixosConfigurations."john.lan" = inputs.nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [ ./test/configuration.nix ];
+        };
+        test.by-nixosConfigurations = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixOS {
+            ssh.destination = "john.local";
+            configuration = self.nixosConfigurations."john.lan";
+          }
+        );
+        test.by-configuration-file = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixOS {
+            ssh.destination = "john.local";
+            # not recommended if you have proper nixosConfigurations to pull from
+            configuration = ./test/configuration.nix;
+          }
+        );
+        test.by-configuration-file-buildOnDestination = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixOS {
+            ssh.destination = "john.local";
+            ssh.buildOnDestination = true;
+            # not recommended if you have proper nixosConfigurations to pull from
+            configuration = ./test/configuration.nix;
+          }
+        );
+        test.by-nixosConfigurations-buildOnDestination = withSystem "x86_64-linux" ({ hci-effects, ... }:
+          hci-effects.runNixOS {
+            ssh.destination = "john.local";
+            ssh.buildOnDestination = true;
+            configuration = self.nixosConfigurations."john.lan";
+          }
+        );
+      };
+    })
+  );
+
+  tests = ok:
+
+    # Check some invocations to make sure the glue code evaluates without error.
+    assert
+      isEffect flake1.test.by-nixosConfigurations;
+    assert
+      isEffect flake1.test.by-configuration-file;
+    assert
+      isEffect flake1.test.by-configuration-file-buildOnDestination;
+
+    ok;
+
+}
+

--- a/effects/nixos/run-nixos.nix
+++ b/effects/nixos/run-nixos.nix
@@ -13,19 +13,69 @@ args@{
     configuration ? throw "effects.runNixOS: you must provide a configuration (or a fully evaluated configuration in `config`)",
     system ? throw "effects.runNixOS: you must provide a `system` parameter (or a fully evaluated configuration in `config`)",
     nixpkgs ? path,
-    config ?
-      (
-        import (nixpkgs + "/nixos/lib/eval-config.nix") {
-          modules = [configuration];
-          inherit system;
-        }
-      ).config,
+    config ? null,
     profile ? "/nix/var/nix/profiles/system",
     ssh,
     passthru ? {},
     ...
   }:
   let
+    # An actual configuration object. If only `config` was passed, this will be incomplete.
+    configuration_ = if args?configuration.config && configuration?_module && configuration._type or null == "configuration"
+      then configuration
+      else if args?config
+      then { inherit (args) config; }  # incomplete, but permissible for backcompat
+      else if args?configuration
+      then import (nixpkgs + "/nixos/lib/eval-config.nix") {
+          modules = [configuration];
+          inherit system;
+        }
+      else throw "effects.runNixOS: you must provide a configuration";
+
+    config = configuration_.config;
+
+    ssh' = { inherit destinationPkgs; } // ssh;
+
+    # Only evaluated when ssh.buildOnDestination = true.
+    # Ideally this whole thing goes away when Nix gives good access to a string's
+    # derivation paths in pure mode.
+    destinationPkgs =
+      configuration_._module.args.pkgs or (throw ''
+        runNixOS: ssh.destinationPkgs is required when
+          - invoking effects.runNixOS with just a config parameter
+          - and ssh.buildOnDestination = true;
+
+        Ideally you could pass a whole NixOS configuration object instead of just the config attribute.
+        Consider changing your invocation to match one of the following examples,
+        whichever is easiest for you:
+
+            runNixOS {
+              configuration = self.nixosConfigurations.foo;
+              # or
+              # configuration = lib.nixosSystem ./configuration.nix;
+              # or
+              # configuration = import (nixpkgs + "/nixos/lib/eval-config.nix") { ... };
+            }
+
+        Or let runNixOS perform the NixOS invocation for you, e.g.
+
+            runNixOS {
+              configuration = ./configuration.nix;
+            }
+
+        Or pass a suitable pkgs, buildable on the destination, by hand:
+
+            runNixOS {
+              ssh = {
+                # ...
+
+                destinationPkgs = nixpkgs.legacyPackages.x86_64-linux;
+                # or e.g.
+                # destinationPkgs = import nixpkgs { system = "x86_64-linux"; };
+              };
+            }
+      '');
+
     checked =
       if !(config ? environment.systemPackages)
       then throw "effects.runNixOS expects `config` to be an already evaluated configuration, like the `config` variable that's used in NixOS modules. Perhaps you intended to write `configuration` instead of `config`?"
@@ -40,7 +90,7 @@ args@{
     ];
     effectScript = ''
       ${args.effectScript or ""}
-      ${effects.ssh ssh ''
+      ${effects.ssh ssh' ''
         set -euo pipefail
         echo >&2 "remote nix version:"
         nix-env --version >&2

--- a/effects/nixos/run-nixos.nix
+++ b/effects/nixos/run-nixos.nix
@@ -11,7 +11,8 @@ let
 in
 args@{
     configuration ? throw "effects.runNixOS: you must provide a configuration (or a fully evaluated configuration in `config`)",
-    system ? throw "effects.runNixOS: you must provide a `system` parameter (or a fully evaluated configuration in `config`)",
+    # null means let the configuration specify it
+    system ? null,
     nixpkgs ? path,
     config ? null,
     profile ? "/nix/var/nix/profiles/system",

--- a/effects/nixos/test/configuration.nix
+++ b/effects/nixos/test/configuration.nix
@@ -1,0 +1,4 @@
+{
+  imports = [ ./hardware-configuration.nix ];
+  boot.loader.grub.enable = false;
+}

--- a/effects/nixos/test/hardware-configuration.nix
+++ b/effects/nixos/test/hardware-configuration.nix
@@ -1,0 +1,4 @@
+{
+  fileSystems."/".device = "/dev/sda123";
+  nixpkgs.hostPlatform = "x86_64-linux";
+}

--- a/effects/ssh/call-ssh.nix
+++ b/effects/ssh/call-ssh.nix
@@ -25,6 +25,8 @@ in
 , compressClosure ? compress
 , compressSession ? compress
 , inheritVariables ? []
+, buildOnDestination ? false
+, destinationPkgs ? throw "hci-effects.ssh: buildOnDestination is true, but destinationPkgs is not set. Please set destinationPkgs to a Nixpkgs instance that is buildable on the destination."
 }:
 
 remoteCommands:
@@ -32,7 +34,36 @@ remoteCommands:
 let
 
   commands = optionalString (inheritVariables != []) ''"$(declare -p ${escapeShellArgs inheritVariables});"''
-    + lib.escapeShellArg remoteCommands;
+    + lib.escapeShellArg remoteCommands';
+
+  remoteCommands' =
+    if buildOnDestination
+    then destinationBuild remoteCommands
+    else remoteCommands;
+
+  # Turn a binary deployment into a source deployment.
+  # type: string of bash statements -> string of bash statements
+  #
+  # Ideally we don't use and don't ask for destinationPkgs, but instead we
+  # retrieve the derivation paths directly, without constructing an unnecessary
+  # derivation (`file` below).
+  # Such an approach would be possible with builtins.storePath, but that isn't
+  # available in pure mode, yet(?).
+  # See https://github.com/NixOS/nix/issues/5868#issuecomment-1757869475
+  destinationBuild = commands:
+    let
+      file = destinationPkgs.writeText "remote-commands-after-build" commands;
+
+      # Why `eval`? `source` would change the environment slightly.
+    in ''
+      (
+        _call_ssh_script=$(nix-store -vr ${builtins.unsafeDiscardOutputDependency file.drvPath})
+        eval "$(cat "$_call_ssh_script")"
+        r=$?
+        nix-store --delete "$_call_ssh_script" || echo "Failed to delete script file from store; ignoring."
+        exit $r
+      )
+    '';
 
   # TODO (2022-01): Use upstream function: https://github.com/NixOS/nixpkgs/pull/123111
   writeDirectReferencesToFile = path: runCommand "runtime-references"
@@ -59,7 +90,7 @@ let
       sort ./references >$out
     '';
 
-  referencesFile = writeDirectReferencesToFile (writeText "remote-commands" remoteCommands);
+  referencesFile = writeDirectReferencesToFile (writeText "remote-commands" remoteCommands');
 in ''(
   export PATH="${makeBinPath [nix ssh]}:$PATH"
   _call_ssh_references="''${ssh_copy_paths:-}''${ssh_copy_paths:+ }$(cat ${referencesFile})"

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -11,6 +11,10 @@ top@{ withSystem, lib, inputs, config, self, ... }: {
         (import ./flake-modules/derivationTree-type.nix { inherit lib; }).tests
           inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile;
 
+      evaluation-runNixOS =
+        let it = (import ./effects/nixos/eval-test.nix { inherit inputs; });
+        in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };
+
       evaluation-herculesCI =
         let it = (import ./flake-modules/herculesCI-eval-test.nix { inherit inputs; });
         in it.tests inputs.nixpkgs.legacyPackages.x86_64-linux.emptyFile // { debug = it; };

--- a/lib/testSupport.nix
+++ b/lib/testSupport.nix
@@ -21,9 +21,14 @@ let
     sourceInfo = { };
   };
 
+  testEqDrv = drv1: drv2:
+    if drv1 == drv2 then true
+    else builtins.trace "Oh-oh, these are different! Check the differences with\nnix-diff --color=always ${drv1} ${drv2} | less -RS" false;
+
 in {
   inherit
     callFlake
     callFlakeOutputs
+    testEqDrv
     ;
 }


### PR DESCRIPTION
### Motivation

- Allow realisation to happen on the destination instead.
  Useful for bootstrapping an agent with the `hci` command.

- Modernize `runNixOS` a bit

- Docs improvements

### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [x] Is the corresponding module up to date?
   - n/a