### PR TITLE
git-update: allow force push after rebase, safely

### DIFF
--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixDarwin.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixDarwin.adoc
@@ -36,7 +36,7 @@ hci-effects.runNixDarwin {
 
 
 [[param-buildOnDestination]]
-== `buildOnDestination`
+=== `buildOnDestination`
 
 Default: value of `ssh.buildOnDestination`, which defaults to `false`.
 

--- a/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
+++ b/docs/modules/ROOT/pages/reference/nix-functions/runNixOS.adoc
@@ -31,7 +31,7 @@ TIP: This function has a how-to guide. See xref:guide/deploy-a-nixos-machine.ado
 
 
 [[param-buildOnDestination]]
-== `buildOnDestination`
+=== `buildOnDestination`
 
 Default: value of `ssh.buildOnDestination`, which defaults to `false`.
 

--- a/effects/modules/git-update.nix
+++ b/effects/modules/git-update.nix
@@ -213,7 +213,13 @@ in
       if [[ "$rev_before" == "$rev_after" ]]; then
         echo 1>&2 'No updates to push.'
       else
-        git push origin "$HCI_GIT_UPDATE_BRANCH"
+        declare -a gitPushArgs
+        case "''${HCI_GIT_UPDATE_BASE_MERGE_METHOD:-}" in
+          rebase)
+            gitPushArgs+=(--force-with-lease)
+            ;;
+        esac
+        git push origin "$HCI_GIT_UPDATE_BRANCH" ''${gitPushArgs[@]}
       fi
     '' + optionalString cfg.pullRequest.enable ''
       # Too many PRs is better than to few. Ensure that the PR exists

--- a/effects/modules/git-update/test.nix
+++ b/effects/modules/git-update/test.nix
@@ -17,13 +17,16 @@ let
   };
 
 in
+
+# TODO: move some properties that are tested in flake-update to this test
+
 effectVMTest {
   imports = [
     ../../testsupport/dns.nix
     ../../testsupport/gitea.nix
     ../../testsupport/setup.nix
   ];
-  name = "flake-update";
+  name = "git-update";
   effects = {
     update = hci-effects.modularEffect {
       imports = [ baseUpdate ];


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->

Make `git.update.baseMerge.method = "rebase"` work in non-trivial cases.






<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [ ] Documentation (function reference docs, setup guide, option reference docs)
    - n/a
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
    - n/a