### PR TITLE
Add populate-cache-effect

### DIFF
--- a/effects/populate-cache/default.nix
+++ b/effects/populate-cache/default.nix
@@ -1,0 +1,179 @@
+{inputs, withSystem, ...}:
+let
+  attic-client = inputs.attic.packages."x86_64-linux".attic-client;
+  cachix = withSystem "x86_64-linux" ({pkgs, ...}: pkgs.cachix);
+  in
+{
+  inputs,
+  lib,
+  withSystem,
+  config,
+  ...
+}: {
+  imports = [
+    inputs.hercules-ci-effects.flakeModule
+  ];
+
+  options = {
+    populate-cache-effect = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Enables HerculesCI effects populating some external cache.";
+      };
+      attic-client-pkg = lib.mkOption {
+        type = lib.types.package;
+        description = "Version of the attic-client package to use on \"x86_64-linux\".";
+        default = attic-client;
+      };
+      cachix-pkg = lib.mkOption {
+        type = lib.types.package;
+        description = "Version of the cachix package to use on \"x86_64-linux\".";
+        default = cachix;
+      };
+      caches = lib.mkOption {
+        description = "
+          An attribute set, each `name: value` pair translates to an effect under
+          onPush.default.outputs.effects.populate-cache-effect.name
+        ";
+        example = "
+          {
+            our-cachix = {
+              type = \"cachix\";
+              secretName = \"our-cachix-token\";
+              branches = [ \"master\" ];
+              packages = [ pkgs.hello ];
+            };
+          }
+        ";
+        type = lib.types.attrsOf (lib.types.submodule (
+          {name, ...}: {
+            options = {
+              name = lib.mkOption {
+                type = lib.types.str;
+                default = name;
+                description = ''
+                  Name of the effect. By default it's the attribute name.
+                '';
+              };
+              type = lib.mkOption {
+                type = lib.types.enum ["attic" "cachix"];
+                description = "A string \"attic\" or \"cachix\".";
+              };
+              packages = lib.mkOption {
+                type = with lib.types; listOf package;
+                description = "List of packages to push to the cache.";
+                example = "[ pkgs.hello ]";
+              };
+              secretName = lib.mkOption {
+                type = lib.types.str;
+                description = ''
+                  Name of the HerculesCI secret. See [HerculesCI docs](https://docs.hercules-ci.com/hercules-ci-agent/secrets-json).
+                  The secrets "data" field should contain given data:
+
+                  ```
+                    "data": {
+                      "name": "my-cache-name",
+                      "token": "ey536428341723812",
+                      "endpoint": "https://my-cache-name.com"
+                    }
+                  ```
+
+                  The "endpoint" field is needed for Attic cache. With Cachix cache the "endpoint" field is not read and can be absent.
+                '';
+              };
+              branches = lib.mkOption {
+                type = with lib.types; listOf str;
+                description = ''
+                  Branches on which we'd like to execute the effect.
+                '';
+              };
+            };
+          }
+        ));
+      };
+    };
+  };
+
+  config = let
+    # file with all the package paths written line by line
+    # nixpkgs -> [derivation] -> derivation
+    packagesFile = pkgs: packages:
+      pkgs.writeText "pushed-paths"
+      (lib.strings.concatStringsSep "\n" (builtins.map builtins.toString packages));
+
+    mkAtticPushEffect = {
+      cacheOptions,
+      branch,
+    }:
+      withSystem "x86_64-linux" (
+        {
+          hci-effects,
+          pkgs,
+          ...
+        }: let
+          pushEffect = hci-effects.mkEffect {
+            inputs = [attic-client-pkg];
+            secretsMap = {
+              token-file = "${cacheOptions.secretName}";
+            };
+            userSetupScript = ''
+              attic login \
+                server-name \
+                $(readSecretString token-file .endpoint) \
+                $(readSecretString token-file .token)
+            '';
+            effectScript = ''
+              cat ${packagesFile pkgs cacheOptions.packages} | xargs -s 4096 attic push server-name:$(readSecretString token-file .name)
+            '';
+          };
+        in
+          hci-effects.runIf (builtins.elem branch cacheOptions.branches) pushEffect
+      );
+
+    mkCachixPushEffect = {
+      cacheOptions,
+      branch,
+    }:
+      withSystem "x86_64-linux" (
+        {
+          hci-effects,
+          pkgs,
+          ...
+        }: let
+          pushEffect = hci-effects.mkEffect {
+            inputs = [cachix];
+            secretsMap = {
+              token-file = "${cacheOptions.secretName}";
+            };
+            userSetupScript = ''
+              cachix authtoken $(readSecretString token-file .token)
+            '';
+            effectScript = ''
+              cat ${packagesFile pkgs cacheOptions.packages} | cachix push $(readSecretString token-file .name)
+            '';
+          };
+        in
+          hci-effects.runIf (builtins.elem branch cacheOptions.branches) pushEffect
+      );
+  in
+    lib.mkIf config.populate-cache-effect.enable {
+      herculesCI = herculesConfig: {
+        onPush.default.outputs.effects.populate-cache-effect =
+          lib.attrsets.mapAttrs' (_: cacheOptions: {
+            inherit (cacheOptions) name;
+            value = builtins.getAttr "${cacheOptions.type}" {
+              attic = mkAtticPushEffect {
+                inherit cacheOptions;
+                inherit (herculesConfig.config.repo) branch;
+              };
+              cachix = mkCachixPushEffect {
+                inherit cacheOptions;
+                inherit (herculesConfig.config.repo) branch;
+              };
+            };
+          })
+          config.populate-cache-effect.caches;
+      };
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,75 @@
 {
   "nodes": {
+    "attic": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1698258239,
+        "narHash": "sha256-qnhoYYIJ0L/P7H/f56lQUEvpzNlXh4sxuHpRERV+B44=",
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "e9918bc6be268da6fa97af6ced15193d8a0421c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": [
+          "attic",
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "attic",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "attic",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1677892403,
+        "narHash": "sha256-/Wi0L1spSWLFj+UQxN3j0mPYMoc7ZoAujpUF/juFVII=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "105e27adb70a9890986b6d543a67761cbc1964a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -19,6 +89,21 @@
         "type": "indirect"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1697723726,
@@ -35,10 +120,54 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685004253,
+        "narHash": "sha256-AbVL1nN/TDicUQ5wXZ8xdLERxz/eJr7+o8lqkIOVuaE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e01645c40b92d29f3ae76344a6d654986a91a91",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "attic": "attic",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "attic",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "attic",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1675391458,
+        "narHash": "sha256-ukDKZw922BnK5ohL9LhwtaDAdCsJL7L6ScNEyF1lO9w=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "383a4acfd11d778d5c2efcf28376cbd845eeaedf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,12 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+  inputs.attic = {
+    url = "github:zhaofengli/attic";
+    inputs = {
+      nixpkgs.follows = "nixpkgs";
+    };
+  };
 
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; }


### PR DESCRIPTION
### Motivation

We want to push some paths to either the cachix or attic cache, additionaly to the cache configured for herculesCI. We discussed it recently on mlabs slack. If you guys would be interested here's a module doing that to be used like below:

```nix
populate-cache-effect = {
      enable = true;
      caches = {
        mlabs-attic = {
          type = "attic";
          secretName = "cardano-nix-attic-token";
          branches = ["master"];
          packages = [test-drv];
        };
        mlabs-cachix = {
          type = "cachix";
          secretName = "karol-cachix-token";
          branches = ["master" "push-to-attic"];
          packages = [test-drv];
        };
      };
    };
```

it's a flake-parts module producing effects under `herculesCI.onPush.default.outputs.effects.populate-cache-effect` option.

### Questions

It works. But I don't understand the structure of this repository, so I'd like to ask first how to incorporate that into the codebase: 

 - where/how to export this
 - if it's fine the way it is with default `attic-client-pkg` `cachix-pkg`




<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [ ] Documentation (function reference docs, setup guide, option reference docs)
 - [ ] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
