### PR TITLE
maint: Update default-herculesCI-for-flake.nix

### DIFF
--- a/vendor/hercules-ci-agent/default-herculesCI-for-flake.nix
+++ b/vendor/hercules-ci-agent/default-herculesCI-for-flake.nix
@@ -52,7 +52,10 @@ let
     then attrs: attrs
     else intersectAttrs ciSystems;
 
-  getSystemNixDarwin = sys: sys.config.nixpkgs.system;
+  getSystemNixDarwin = sys:
+    if sys?options.nixpkgs.hostPlatform && sys.options.nixpkgs.hostPlatform.isDefined
+    then sys.config.nixpkgs.buildPlatform.system
+    else sys.config.nixpkgs.localSystem.system or sys.config.nixpkgs.system;
 
   getSystemNixOS = sys:
     if sys?options.nixpkgs.hostPlatform && sys.options.nixpkgs.hostPlatform.isDefined


### PR DESCRIPTION

### Motivation
<!-- What is the end goal of the change? -->


Fixes ciSystems filtering for nix-darwin.

See https://github.com/hercules-ci/hercules-ci-agent/pull/578






<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [ ] Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
