### PR TITLE
feat: Add mounts option to modularEffect

### DIFF
--- a/effects/effect/effect-module.nix
+++ b/effects/effect/effect-module.nix
@@ -71,6 +71,21 @@ in
       default = { };
     };
 
+    mounts = mkOption {
+      type = types.lazyAttrsOf types.str;
+      description = ''
+        _Since hercules-ci-agent 0.10.1_
+
+        Mounts that are made available to the effect.
+        The keys are the mount points.
+        The values are the keys of the [`effectMountables`](https://docs.hercules-ci.com/hercules-ci-agent/agent-config#effectMountables) configured on the agents.
+      '';
+      default = { };
+      example = {
+        "/dev/kvm" = "dev-kvm";
+      };
+    };
+
     src = mkOption {
       type = types.nullOr types.path;
       description = ''
@@ -172,6 +187,7 @@ in
         getStateScript
         putStateScript
         ;
+      __hci_effect_mounts = builtins.toJSON config.mounts;
       passthru = config.extraAttributes;
     }
     // filterAttrs (k: v: v != null) {

--- a/effects/effect/test/dev-kvm.nix
+++ b/effects/effect/test/dev-kvm.nix
@@ -1,0 +1,10 @@
+{ modularEffect }:
+
+modularEffect {
+  effectScript = ''
+    echo Checking /dev/kvm access
+    stat /dev/kvm || :
+    test -r /dev/kvm
+  '';
+  mounts."/dev/kvm" = "kvm";
+}

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -64,6 +64,9 @@ top@{ withSystem, lib, inputs, config, self, ... }: {
         {
           tests = top.config.flake.tests // {
             netlifyDeploy = pkgs.callPackage ./effects/netlify/test/default.nix { inherit (config.repo) rev; };
+            dev-kvm = withSystem "x86_64-linux" ({ pkgs, hci-effects, ... }:
+              hci-effects.callPackage ./effects/effect/test/dev-kvm.nix { }
+            );
           };
         };
     };


### PR DESCRIPTION
### Motivation


Make use of `__hci_effect_mounts` convenient - mount any path into the effect, [as permitted](https://docs.hercules-ci.com/hercules-ci-agent/agent-config#effectMountables) by the agent.

<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
