### PR TITLE
fix: Always mkdir -p $parent in gitWriteBranch

### DIFF
--- a/effects/write-branch/effect-module.nix
+++ b/effects/write-branch/effect-module.nix
@@ -71,9 +71,8 @@ in
 
       if test -e "$destination"; then
         git rm -rf "$destination"
-      else
-        mkdir -p "$(dirname "$destination")"
       fi
+      mkdir -p "$(dirname "$destination")"
 
       if test -d "''${contents}"; then
         contents="''${contents}/."

--- a/effects/write-branch/test.nix
+++ b/effects/write-branch/test.nix
@@ -157,5 +157,27 @@ effectVMTest {
         )
       """)
 
+    with subtest("Files and directories can be put in a directory without replacing everything, also when removing the destination removes its parent directories"):
+      # Since www/public is the only entry in www, git will remove www as well
+      # This must be handled by the effect, by creating the parent: www
+      agent.succeed(f"echo {gitea_admin_password} | effect-write-contents-destination")
+      client.succeed("""
+        (
+          set -x
+          cd repo
+          git pull
+          test index.md
+          ! test -e bin
+          ! test -e .i-am-hidden
+          test -r www/public/index.md
+          test -r www/public/.i-am-hidden
+          test -x www/public/bin/hello
+          test -L www/public/bin/greet
+
+          lines=$(git log | grep -F 'Update www/public' | wc -l)
+          [[ 1 == $lines ]]
+        )
+      """)
+
   '';
 }


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->

Fix bug.






<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [x] n/a Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [x] Is the corresponding module up to date?
