### PR TITLE
Add uid and gid in modularEffect

### DIFF
--- a/effects/effect/effect-module.nix
+++ b/effects/effect/effect-module.nix
@@ -159,6 +159,32 @@ in
       default = null;
     };
 
+    uid = mkOption {
+      type = types.int;
+      description = ''
+        _Since hercules-ci-agent 0.10.1_
+
+        The virtual user id, which processes in the contain think they have.
+
+        The real user id is always that of the hercules-ci-agent that runs the effect, or that of the user calling [`hci effect run`](https://docs.hercules-ci.com/hercules-ci-agent/hci/effect/run).
+
+        See also [`gid`](https://docs.hercules-ci.com/hercules-ci-effects/reference/effect-modules/core.html#_gid).
+      '';
+      default = 0;
+    };
+
+    gid = mkOption {
+      type = types.int;
+      description = ''
+        _Since hercules-ci-agent 0.10.1_
+
+        The virtual group id, which processes in the contain think they have.
+
+        See [`uid`](https://docs.hercules-ci.com/hercules-ci-effects/reference/effect-modules/core.html#_uid).
+      '';
+      default = 0;
+    };
+
     extraAttributes = mkOption {
       description = ''
         Attributes to add to the returned effect. These only exist at the expression level and do not become part of the executable effect.
@@ -194,6 +220,8 @@ in
         putStateScript
         ;
       __hci_effect_mounts = builtins.toJSON config.mounts;
+      __hci_effect_virtual_uid = config.uid;
+      __hci_effect_virtual_gid = config.gid;
       passthru = config.extraAttributes;
     }
     // filterAttrs (k: v: v != null) {

--- a/effects/effect/test/uid.nix
+++ b/effects/effect/test/uid.nix
@@ -1,0 +1,23 @@
+{ hci-effects, nix ? null }:
+
+hci-effects.effectVMTest {
+  name = "uid";
+  effects = {
+    uid-check = hci-effects.modularEffect {
+      uid = 123;
+      gid = 456;
+      effectScript = ''
+      (
+        set -x
+        : "Checking UID"
+        test "$(id -u)" -eq 123
+        : "Checking GID"
+        test "$(id -g)" -eq 456
+      )
+      '';
+    };
+  };
+  testScript = ''
+    agent.succeed("effect-uid-check")
+  '';
+}

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -46,6 +46,7 @@ top@{ withSystem, lib, inputs, config, self, ... }: {
       cachix-deploy = pkgs.callPackage ./effects/cachix-deploy/test.nix { };
       mkEffect = pkgs.callPackage ./effects/effect/test.nix { };
       nixos = hci-effects.callPackage ./effects/nixos/test.nix { };
+      uid = hci-effects.callPackage ./effects/effect/test/uid.nix { };
     });
   };
 


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->

Some applications simply don't like to be UID 0, even if it's harmless.

Specifying `__hci_effect_*` by hand isn't very nice.




<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
 - [x] Is the corresponding module up to date?
    - now it is