### PR TITLE
runNixDarwin: add `-H` to sudo

### DIFF
--- a/effects/nix-darwin/run-nix-darwin.nix
+++ b/effects/nix-darwin/run-nix-darwin.nix
@@ -132,7 +132,7 @@ mkEffect (removeAttrs args [ "configuration" "ssh" "config" "system" "nix-darwin
       echo >&2 "remote nix version:"
       nix-env --version >&2
       if [ "$USER" != root ] && [ ! -w $(dirname "${profilePath}") ]; then
-        sudo nix-env -p ${profilePath} --set ${toplevel}
+        sudo -H nix-env -p ${profilePath} --set ${toplevel}
       else
         nix-env -p ${profilePath} --set ${toplevel}
       fi


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->

fixes this warning:

warning: $HOME ('/Users/customer') is not owned by you, falling back to the one defined in the 'passwd' file ('/var/root')

matches the sudo command used in nix-darwin:

https://github.com/LnL7/nix-darwin/blob/87131f51f8256952d1a306b5521cedc2dc61aa08/pkgs/nix-tools/darwin-rebuild.sh#L27






<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [ ] Documentation (function reference docs, setup guide, option reference docs)
 - [ ] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
