### PR TITLE
Add `/bin/sh` and other fs root things

### DIFF
--- a/effects/effect/effect-module.nix
+++ b/effects/effect/effect-module.nix
@@ -1,4 +1,4 @@
-{ config, lib, hci-effects, ... }:
+{ config, lib, hci-effects, pkgs, ... }:
 let
   inherit (lib)
     filterAttrs
@@ -185,6 +185,19 @@ in
       default = 0;
     };
 
+    binsh = mkOption {
+      type = types.nullOr types.str;
+      description = ''
+        The target for the `/bin/sh` symlink.
+
+        If set to `null`, `/bin/sh` will not be created.
+      '';
+      defaultText = lib.literalMD ''
+        `lib.getExe pkgs.bash`, where `pkgs` is the `pkgs` argument that was [passed to the library](https://docs.hercules-ci.com/hercules-ci-effects/guide/import-or-pin).
+      '';
+      default = lib.getExe pkgs.bash;
+    };
+
     extraAttributes = mkOption {
       description = ''
         Attributes to add to the returned effect. These only exist at the expression level and do not become part of the executable effect.
@@ -222,6 +235,7 @@ in
       __hci_effect_mounts = builtins.toJSON config.mounts;
       __hci_effect_virtual_uid = config.uid;
       __hci_effect_virtual_gid = config.gid;
+      __hci_effect_binsh = config.binsh;
       passthru = config.extraAttributes;
     }
     // filterAttrs (k: v: v != null) {

--- a/effects/effect/effect-module.nix
+++ b/effects/effect/effect-module.nix
@@ -198,6 +198,39 @@ in
       default = lib.getExe pkgs.bash;
     };
 
+    usrbinenv = mkOption {
+      type = types.nullOr types.str;
+      description = ''
+        The target for the `/usr/bin/env` symlink.
+
+        If set to `null`, `/usr/bin/env` will not be created.
+      '';
+      defaultText = lib.literalMD ''
+        `"''${pkgs.coreutils}/bin/env"`, where `pkgs` is the `pkgs` argument that was [passed to the library](https://docs.hercules-ci.com/hercules-ci-effects/guide/import-or-pin).
+      '';
+      default = "${pkgs.coreutils}/bin/env";
+    };
+
+    fsRoot = mkOption {
+      type = types.path;
+      description = ''
+        A store path whose contents will be copied to the effect's filesystem root.
+      '';
+      defaultText = lib.literalExpression ''
+        pkgs.runCommand "effect-fs-root" { } fsRootBuildCommands
+      '';
+    };
+
+    fsRootBuildCommands = mkOption {
+      type = types.lines;
+      description = ''
+        The build commands to run to create the filesystem root.
+
+        This is a list of bash statements, which are run as a Nix build - _not_ in the effect sandbox but beforehand.
+      '';
+      defaultText = lib.literalMD "Add `binsh` and `usrbinenv` to `$out`. This default has normal priority so that any user-defined statements are added to it.";
+    };
+
     extraAttributes = mkOption {
       description = ''
         Attributes to add to the returned effect. These only exist at the expression level and do not become part of the executable effect.
@@ -235,7 +268,7 @@ in
       __hci_effect_mounts = builtins.toJSON config.mounts;
       __hci_effect_virtual_uid = config.uid;
       __hci_effect_virtual_gid = config.gid;
-      __hci_effect_binsh = config.binsh;
+      __hci_effect_fsroot_copy = config.fsRoot;
       passthru = config.extraAttributes;
     }
     // filterAttrs (k: v: v != null) {
@@ -247,6 +280,20 @@ in
     }
     // config.env # TODO warn about collisions
     ;
+
+    fsRoot = pkgs.runCommand "effect-fs-root" { } config.fsRootBuildCommands;
+
+    fsRootBuildCommands =
+      lib.mkMerge [
+        (lib.mkIf (config.binsh != null) ''
+          mkdir -p $out/bin
+          ln -s ${lib.escapeShellArg config.binsh} $out/bin/sh
+        '')
+        (lib.mkIf (config.usrbinenv != null) ''
+          mkdir -p $out/usr/bin
+          ln -s ${lib.escapeShellArg config.usrbinenv} $out/usr/bin/env
+        '')
+      ];
 
     extraAttributes.tests.buildable =
       (config.effectDerivation.overrideAttrs (o: { isEffect = false; })).inputDerivation;

--- a/effects/effect/effect-module.nix
+++ b/effects/effect/effect-module.nix
@@ -283,6 +283,7 @@ in
 
     fsRoot = pkgs.runCommand "effect-fs-root" { } config.fsRootBuildCommands;
 
+    # NB: Sync with mkEffect
     fsRootBuildCommands =
       lib.mkMerge [
         (lib.mkIf (config.binsh != null) ''

--- a/effects/effect/effect.nix
+++ b/effects/effect/effect.nix
@@ -1,4 +1,4 @@
-{ cacert, curl, jq, lib, runCommand, stdenvNoCC,
+{ bash, cacert, coreutils, curl, jq, lib, runCommand, stdenvNoCC,
 
   # Optional, used by nixpkgs version check.
   revInfo ? "",
@@ -58,6 +58,14 @@ let
 
 in
 invokeOverride mkDrv {
+
+  /** If you'd like to customize this, use modularEffect instead. */
+  # NB: Sync with modularEffect
+  __hci_effect_fsroot_copy = runCommand "mkEffect-root" {} ''
+    mkdir -p $out/bin $out/usr/bin
+    ln -s ${lib.getExe bash} $out/bin/sh
+    ln -s ${coreutils}/bin/env $out/usr/bin/env
+  '';
 
   preGetStatePhases = "";
   preEffectPhases = "priorCheckPhase";

--- a/effects/effect/effects-setup-hook.sh
+++ b/effects/effect/effects-setup-hook.sh
@@ -3,27 +3,13 @@
 # ----------------------------------------------------------------------------
 # prepare headers file for curl to talk to Hercules CI
 
-installBinSh() {
-  if ! [[ -e /bin/sh ]] && [[ -n "$__hci_effect_binsh" ]]; then
-    (
-      mkdir -p /bin
-      ln -s "$__hci_effect_binsh" /bin/sh
-    ) ||
-      {
-        echo -e "\e[31m" # RED
-        echo "Failed to create /bin/sh symlink"
-        echo -e "\e[0m"
-        echo "This error can be avoided with one of:"
-        echo "  - __hci_effect_root_read_only = true;"
-        echo "    This may make the installation of /bin/sh work."
-        echo "  - __hci_effect_binsh = null;"
-        echo "    This removes /bin/sh, but may break certain programs."
-        echo "Not all effects need /bin/sh, so we'll continue without it."
-        echo
-      }
+installFSRootFiles() {
+  # Compatibility hook: hercules-ci-agent <= 0.10.5 does not copy for us. Requires rw root.
+  if [[ -z "${__hci_effect_fsroot_copied:-}" && -n "${__hci_effect_fsroot_copy:-}" ]]; then
+    cp --no-preserve=ownership --recursive --reflink=auto -T "$__hci_effect_fsroot_copy"/ /;
   fi
 }
-preInitHooks+=("installBinSh")
+preInitHooks+=("installFSRootFiles")
 
 initHerculesCIAPI() {
   herculesCIHeaders=$PWD/hercules-ci.headers

--- a/effects/effect/effects-setup-hook.sh
+++ b/effects/effect/effects-setup-hook.sh
@@ -1,15 +1,28 @@
+###
+### Nixpkgs / stdenv / setup.sh hook for Hercules CI Effects
+###
+### hercules-ci-effects uses stdenv and setup.sh to structure its effects.
+### This file is sourced by setup.sh and contains the logic to set up the
+### environment for the effect.
+###
+### The effect sandbox environment is similar to that of a Nix build, but
+### with some differences. This file closes that gap a bit and provides
+### some effect-specific utilities.
 
 
 # ----------------------------------------------------------------------------
-# prepare headers file for curl to talk to Hercules CI
+# compat logic for hercules-ci-agent <= 0.10.5 to support __hci_effect_fsroot_copy
 
 installFSRootFiles() {
-  # Compatibility hook: hercules-ci-agent <= 0.10.5 does not copy for us. Requires rw root.
+  # Requires rw root or hercules-ci-agent > 0.10.5 (TBD)
   if [[ -z "${__hci_effect_fsroot_copied:-}" && -n "${__hci_effect_fsroot_copy:-}" ]]; then
     cp --no-preserve=ownership --recursive --reflink=auto -T "$__hci_effect_fsroot_copy"/ /;
   fi
 }
 preInitHooks+=("installFSRootFiles")
+
+# ----------------------------------------------------------------------------
+# prepare headers file for curl to talk to Hercules CI
 
 initHerculesCIAPI() {
   herculesCIHeaders=$PWD/hercules-ci.headers

--- a/effects/effect/effects-setup-hook.sh
+++ b/effects/effect/effects-setup-hook.sh
@@ -3,6 +3,27 @@
 # ----------------------------------------------------------------------------
 # prepare headers file for curl to talk to Hercules CI
 
+installBinSh() {
+  if ! [[ -e /bin/sh ]] && [[ -n "$__hci_effect_binsh" ]]; then
+    (
+      mkdir -p /bin
+      ln -s "$__hci_effect_binsh" /bin/sh
+    ) ||
+      {
+        echo -e "\e[31m" # RED
+        echo "Failed to create /bin/sh symlink"
+        echo -e "\e[0m"
+        echo "This error can be avoided with one of:"
+        echo "  - __hci_effect_root_read_only = true;"
+        echo "    This may make the installation of /bin/sh work."
+        echo "  - __hci_effect_binsh = null;"
+        echo "    This removes /bin/sh, but may break certain programs."
+        echo "Not all effects need /bin/sh, so we'll continue without it."
+        echo
+      }
+  fi
+}
+preInitHooks+=("installBinSh")
 
 initHerculesCIAPI() {
   herculesCIHeaders=$PWD/hercules-ci.headers

--- a/effects/effect/test/setup.nix
+++ b/effects/effect/test/setup.nix
@@ -1,24 +1,29 @@
-{ hci-effects }:
+{ hci-effects, modular }:
 
 hci-effects.effectVMTest {
   name = "setup";
   effects = {
-    setup-check = hci-effects.modularEffect {
-      effectScript = ''
-      (
-        set -x
+    setup-check = 
+      let
+        effectScript = ''
+          (
+            set -x
 
-        : "bash is available"
-        bash -c 'echo "Hello world"' | grep -q "Hello world"
+            : "bash is available"
+            bash -c 'echo "Hello world"' | grep -q "Hello world"
 
-        : "/bin/sh works"
-        /bin/sh -c 'echo "Hello world"' | grep -q "Hello world"
+            : "/bin/sh works"
+            /bin/sh -c 'echo "Hello world"' | grep -q "Hello world"
 
-        : "/usr/bin/env works"
-        /usr/bin/env bash -c 'echo "Hello world"' | grep -q "Hello world"
-      )
-      '';
-    };
+            : "/usr/bin/env works"
+            /usr/bin/env bash -c 'echo "Hello world"' | grep -q "Hello world"
+          )
+          '';
+      in
+        if modular then
+          hci-effects.modularEffect { inherit effectScript; }
+        else
+          hci-effects.mkEffect { inherit effectScript; };
   };
   testScript = ''
     agent.succeed("effect-setup-check")

--- a/effects/effect/test/setup.nix
+++ b/effects/effect/test/setup.nix
@@ -7,8 +7,15 @@ hci-effects.effectVMTest {
       effectScript = ''
       (
         set -x
+
+        : "bash is available"
+        bash -c 'echo "Hello world"' | grep -q "Hello world"
+
         : "/bin/sh works"
         /bin/sh -c 'echo "Hello world"' | grep -q "Hello world"
+
+        : "/usr/bin/env works"
+        /usr/bin/env bash -c 'echo "Hello world"' | grep -q "Hello world"
       )
       '';
     };

--- a/effects/effect/test/setup.nix
+++ b/effects/effect/test/setup.nix
@@ -1,0 +1,19 @@
+{ hci-effects }:
+
+hci-effects.effectVMTest {
+  name = "setup";
+  effects = {
+    setup-check = hci-effects.modularEffect {
+      effectScript = ''
+      (
+        set -x
+        : "/bin/sh works"
+        /bin/sh -c 'echo "Hello world"' | grep -q "Hello world"
+      )
+      '';
+    };
+  };
+  testScript = ''
+    agent.succeed("effect-setup-check")
+  '';
+}

--- a/effects/effect/test/uid.nix
+++ b/effects/effect/test/uid.nix
@@ -1,4 +1,4 @@
-{ hci-effects, nix ? null }:
+{ hci-effects }:
 
 hci-effects.effectVMTest {
   name = "uid";

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -114,6 +114,7 @@ top@{ withSystem, lib, inputs, config, self, ... }: {
       # ssh = hci-effects.callPackage ./effects/ssh/test.nix { };
       artifacts-tool = hci-effects.callPackage ./packages/artifacts-tool/test { };
       artifacts-tool-typecheck = hci-effects.callPackage ./packages/artifacts-tool/mypy.nix { };
+      setup = hci-effects.callPackage ./effects/effect/test/setup.nix { };
       github-releases = github-releases-tests.test.simple;
       github-releases-perSystem = github-releases-tests.test.perSystem;
       module-files-readable = checkModules pkgs.emptyFile;

--- a/flake-dev.nix
+++ b/flake-dev.nix
@@ -114,7 +114,8 @@ top@{ withSystem, lib, inputs, config, self, ... }: {
       # ssh = hci-effects.callPackage ./effects/ssh/test.nix { };
       artifacts-tool = hci-effects.callPackage ./packages/artifacts-tool/test { };
       artifacts-tool-typecheck = hci-effects.callPackage ./packages/artifacts-tool/mypy.nix { };
-      setup = hci-effects.callPackage ./effects/effect/test/setup.nix { };
+      setup-modularEffect = hci-effects.callPackage ./effects/effect/test/setup.nix { modular = true; };
+      setup-mkEffect = hci-effects.callPackage ./effects/effect/test/setup.nix { modular = false; };
       github-releases = github-releases-tests.test.simple;
       github-releases-perSystem = github-releases-tests.test.perSystem;
       module-files-readable = checkModules pkgs.emptyFile;


### PR DESCRIPTION
### Motivation

Provide `/bin/sh` and `/usr/bin/env`, because some programs rely on those.
We can do so in a pure way.



<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [x] Documentation (function reference docs, setup guide, option reference docs)
 - [x] Has tests (VM test, free account, and/or test instructions)
 - N/A Is the corresponding module up to date?
