### PR TITLE
artifacts-tool: Don't try to create an existing release

### DIFF
--- a/flake-modules/github-releases/default.nix
+++ b/flake-modules/github-releases/default.nix
@@ -89,6 +89,13 @@ in
         default = herculesCI: herculesCI.config.repo.tag;
         defaultText = lib.literalExpression "herculesCI: herculesCI.config.repo.tag";
       };
+      skipIfExists = mkOption {
+        type = types.bool;
+        description = ''
+          Whether to skip creating the release if it already exists, rather than failing with an error.
+        '';
+        default = false;
+      };
       files = mkOption {
         type = types.listOf fileSpec;
         description = ''
@@ -209,6 +216,7 @@ in
                 inherit (config.repo) owner;
                 repo = config.repo.name;
                 releaseTag = cfg.releaseTag herculesCI;
+                inherit (cfg) skipIfExists;
               };
               inputs = [ pkgs.zip ];
               extraAttributes.files = files;

--- a/flake-modules/github-releases/test.nix
+++ b/flake-modules/github-releases/test.nix
@@ -130,6 +130,32 @@ rec {
     )
   );
 
+  # Like example1, but with skipIfExists enabled
+  example3 = callFlakeOutputs (
+    inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { ... }:
+      {
+        imports = [
+          ../../flake-module.nix
+        ];
+        systems = [ "x86_64-linux" ];
+        defaultEffectSystem = effectSystem;
+        herculesCI.ciSystems = [ "x86_64-linux" ];
+
+        hercules-ci.github-releases = {
+          skipIfExists = true;
+          files = [
+            {
+              label = "test label";
+              path = builtins.toFile "test-file-name" "test-file-contents";
+            }
+          ];
+        };
+      }
+    )
+  );
+
   expectedFiles = [
     {
       label = "test label";
@@ -153,6 +179,9 @@ rec {
   example1Tag = example1.herculesCI (fakeHerculesCI fakeRepoTag);
 
   example2Branch = example2.herculesCI (fakeHerculesCI fakeRepoBranch);
+
+  example3Tag = example3.herculesCI (fakeHerculesCI fakeRepoTag);
+
   expectedFiles2 =
     let
       inherit (inputs.nixpkgs) lib;
@@ -175,8 +204,14 @@ rec {
     assert example1Branch.onPush.default.outputs.effects.github-releases == { };
     assert example1Tag.onPush.default.outputs.effects.github-releases.isEffect;
     assert example1Tag.onPush.default.outputs.effects.github-releases.files == expectedFiles;
+    # skipIfExists defaults to false
+    assert example1Tag.onPush.default.outputs.effects.github-releases.skipIfExists == false;
 
     assert example2Branch.onPush.default.outputs.checks.release-artifacts.files == expectedFiles2;
+
+    # skipIfExists = true propagates to the effect
+    assert example3Tag.onPush.default.outputs.effects.github-releases.isEffect;
+    assert example3Tag.onPush.default.outputs.effects.github-releases.skipIfExists == true;
 
     # Return the checks, so that we can build them in CI
     {

--- a/packages/artifacts-tool/artifacts-tool.py
+++ b/packages/artifacts-tool/artifacts-tool.py
@@ -104,7 +104,7 @@ if "check_only" in environ:
     eprint("check_only is present, creating $out")
     open(environ["out"], "w")
 else:
-    if environ["skipIfExists"] == "1":
+    if environ.get("skipIfExists", "0") == "1":
         existingRelease = subprocess.run(
             [
                 "gh", "release", "view",

--- a/packages/artifacts-tool/artifacts-tool.py
+++ b/packages/artifacts-tool/artifacts-tool.py
@@ -104,6 +104,17 @@ if "check_only" in environ:
     eprint("check_only is present, creating $out")
     open(environ["out"], "w")
 else:
+    if environ["skipIfExists"] == "1":
+        existingRelease = subprocess.run(
+            [
+                "gh", "release", "view",
+                "--repo", f"{environ["owner"]}/{environ["repo"]}",
+                "--json=url", environ["releaseTag"]
+            ]
+        )
+        if existingRelease.returncode == 0:
+            eprint(f"Release {environ["releaseTag"]} already exists, skipping")
+            exit(0)
     for spec in specs:
         if type(spec) is File:
             symlink(spec.path, spec.label)

--- a/packages/artifacts-tool/test/default.nix
+++ b/packages/artifacts-tool/test/default.nix
@@ -1,3 +1,5 @@
+# Run with:
+#   nix build .#checks.x86_64-linux.artifacts-tool
 { pkgs }:
 let
   fake-gh = pkgs.writers.writePython3Bin "gh" { } (builtins.readFile ./fake-gh.py);
@@ -21,6 +23,7 @@ pkgs.runCommandNoCCLocal "github-releases-check"
     export owner=repo_owner
     export repo=repo_name
     export releaseTag=repo_tag
+    export skipIfExists=0
 
     export files='[{"label":"fake-gh","path":"${fake-gh}"}]'
     echo "test should fail: directory"
@@ -31,17 +34,75 @@ pkgs.runCommandNoCCLocal "github-releases-check"
     fi
     echo "OK"
 
+    # Each non-check_only test runs in a fresh directory because artifacts-tool
+    # creates symlinks and then execlp's gh, leaving artifacts behind.
+
     export files='[{"label":"fake-gh","path":"${fake-gh}/bin/gh"}]'
     echo "test should succeed: single file"
+    workdir=$(mktemp -d)
+    pushd "$workdir"
     artifacts-tool && result=0 || result=1
     if [[ $result != 0 ]]; then
       echo "failed"
       exit 1
     fi
     if [[ `cat gh.log` != '["${fake-gh}/bin/gh","release","create","--repo","repo_owner/repo_name","repo_tag","fake-gh"]' ]]; then
+      echo "unexpected gh.log:"
+      cat gh.log
       echo "failed"
       exit 1
     fi
+    popd
     echo "OK"
+
+    # skipIfExists=1, release already exists: should skip without calling release create
+    export skipIfExists=1
+    export FAKE_GH_RELEASE_EXISTS=1
+    echo "test skipIfExists: release exists, should skip"
+    workdir=$(mktemp -d)
+    pushd "$workdir"
+    artifacts-tool && result=0 || result=1
+    if [[ $result != 0 ]]; then
+      echo "expected success, got failure"
+      exit 1
+    fi
+    # gh.log should only contain the release view call, not release create
+    if ! grep -F '"release","view"' gh.log > /dev/null; then
+      echo "expected gh release view call"
+      cat gh.log
+      exit 1
+    fi
+    if grep -F '"release","create"' gh.log > /dev/null; then
+      echo "should not have called gh release create"
+      cat gh.log
+      exit 1
+    fi
+    popd
+    echo "OK"
+
+    # skipIfExists=1, release does not exist: should proceed with release create
+    export FAKE_GH_RELEASE_EXISTS=0
+    echo "test skipIfExists: release does not exist, should create"
+    workdir=$(mktemp -d)
+    pushd "$workdir"
+    artifacts-tool && result=0 || result=1
+    if [[ $result != 0 ]]; then
+      echo "expected success, got failure"
+      exit 1
+    fi
+    # gh.log should contain both the view call and the create call
+    if ! grep -F '"release","view"' gh.log > /dev/null; then
+      echo "expected gh release view call"
+      cat gh.log
+      exit 1
+    fi
+    if ! grep -F '"release","create"' gh.log > /dev/null; then
+      echo "expected gh release create call"
+      cat gh.log
+      exit 1
+    fi
+    popd
+    echo "OK"
+
     touch $out
   ''

--- a/packages/artifacts-tool/test/fake-gh.py
+++ b/packages/artifacts-tool/test/fake-gh.py
@@ -1,7 +1,17 @@
 import json
+import os
 from sys import argv
 
-print(
-  json.dumps(argv, indent=None, separators=(",", ":")),
-  file=open("gh.log", "wt")
-)
+# Log all invocations by appending to gh.log
+with open("gh.log", "at") as f:
+    print(
+        json.dumps(argv, indent=None, separators=(",", ":")),
+        file=f
+    )
+
+# Simulate `gh release view` behavior based on FAKE_GH_RELEASE_EXISTS env var
+if len(argv) >= 3 and argv[1] == "release" and argv[2] == "view":
+    if os.environ.get("FAKE_GH_RELEASE_EXISTS", "0") == "1":
+        exit(0)
+    else:
+        exit(1)


### PR DESCRIPTION
### Motivation
<!-- What is the end goal of the change? -->
What I'm trying to do in https://github.com/hyprspace/hyprspace is:
- Have a package definition in which the version of the overall project is defined. The Git tags should match these versions.
- When I change the version in that package definition (on the master branch), I want to automatically get a new tag (and release) for that version.

To achieve that, I want to use the `github-releases` effect. By makig it run on every push to master, I can get the desired effect, but when the tag already exists, it'll show an error in CI, which doesn't look nice. So, just check if the tag exists (there may be a better way to do this), and if so, don't do anything.

Let me know if you think this is a useful idea or not.

<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [ ] Documentation (function reference docs, setup guide, option reference docs)
 - [ ] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
