### PR TITLE
hercules-ci.github-pages: fix checks

### DIFF
--- a/flake-modules/github-pages.nix
+++ b/flake-modules/github-pages.nix
@@ -114,7 +114,7 @@ in
         };
       in
       {
-        checks = lib.optionalAttrs (system == defaultEffectSystem) {
+        checks = lib.optionalAttrs (cfg.check.enable && system == defaultEffectSystem) {
           github-pages-effect-is-buildable = deploy.tests.buildable;
         };
       };


### PR DESCRIPTION
IIRC hercules will build effect dependencies automatically and this seems to be the only explicit "buildable inputDerivation" check in the repo, would it be better to remove this check entirely?

### Motivation
<!-- What is the end goal of the change? -->








<!--
The following checklist is for the reviewer. If you can tick all boxes, great! If not, we might be able to help.

Please don't remove any items, but leave them unchecked, even if they don't apply.
-->
### Maintainer checklist

 - [ ] Documentation (function reference docs, setup guide, option reference docs)
 - [ ] Has tests (VM test, free account, and/or test instructions)
 - [ ] Is the corresponding module up to date?
